### PR TITLE
OpencastPlugin: add compatibility for plugin-API in 2.3 and 2.4

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -86,7 +86,7 @@ class OpenCast extends StudipPlugin implements StandardPlugin
      * @param string   course_id
      * @param string   last_visit
      */
-    function getIconNavigation($course_id, $last_visit, $user_id)
+    function getIconNavigation($course_id, $last_visit, $user_id = NULL)
     {
         return false;
     }


### PR DESCRIPTION
Ich hab da mal nen kleinen Kniff eingebaut, den ich mir von Rasmus abgekuckt habe - so läuft das Plugin sowohl in 2.3 als ich 2.4, ohne Änderungen vornehmen zu müssen.
