### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
-# Stud.IP Opencast
+# Stud.IP-Opencast-Plugin
 
-This plugin serves as a connection between Opencast Matterhorn and the LMS Stud.IP.
+This plugin serves as a connection between [Opencast](http://opencast.org) and
+the LMS [Stud.IP](http://studip.de/).
 
-Das Opencast Plugin Plugin stellt eine Verbindung zwischen einer Opencast Matterhorn und dem Lernmanagementsystem Stud.IP her. Das Plugin bildet hierbei die Prozesse für das Management von Audio- und Videoinhalten, vor allem für die Aufzeichnung und Distribution von Lehrveranstaltungen im Lernmanagementsystem ab. Bei der Entwicklung des Plugins wurde sicher gestellt, dass folgende typische Anforderungen sichergestellt sind:
+Das Opencast-Plugin stellt eine Verbindung zwischen einer Opencast-Installation
+und dem Lernmanagementsystem Stud.IP her. Das Plugin bildet hierbei die
+Prozesse für das Management von Audio- und Videoinhalten, vor allem für die
+Aufzeichnung und Distribution von Lehrveranstaltungen im Lernmanagementsystem
+ab. Bei der Entwicklung des Plugins wurden folgende typische Anforderungen
+beachtet:
 
-*Transparenz der Aufzeichnungstechnik*: Die DozentIn kann in ihrer Veranstaltung direkt erkennen, ob der gebuchte Veranstaltungsraum mit entsprechender Aufzeichnungstechnik ausgerüstet ist. Dies wird im Plugin durch die Verknüpfung von Stud.IP Ressourcen mit korrespodnierenden Capture Agents aus dem Opencast Matterhon sichergestellt. DozentInnen benötigen hierbei kein technisches Vorwissen über die verwendete Aufzeichnungstechnik.
+*Transparenz der Aufzeichnungstechnik*: Die DozentIn kann in ihrer
+Veranstaltung direkt erkennen, ob der gebuchte Veranstaltungsraum mit
+entsprechender Aufzeichnungstechnik ausgerüstet ist. Dies wird im Plugin durch
+die Verknüpfung von Stud.IP-Ressourcen mit korrespondierenden Capture Agents
+aus Opencast sichergestellt. DozentInnen benötigen hierbei kein technisches
+Vorwissen über die verwendete Aufzeichnungstechnik.
 
-*Einfache Aufzeichnungsplanung*: Vorlesungsaufzeichnugen sollen direkt aus dem Kurs im LMS von der DozentIn geplant werden können. Im Kurs verfügbare Metadaten sollen bei der Planung berücksichtig werden. Realisiert wurde dies im mit einer eigenen Planungsansicht im Plugin, basierend auf der Ablaufplanverwaltung. Hiermit entfällt die mehrfache Eingabe von kursbezogenen Metadaten.
+*Einfache Aufzeichnungsplanung*: Vorlesungsaufzeichnugen sollen direkt aus dem
+Kurs im LMS von der DozentIn geplant werden können. Im Kurs verfügbare
+Metadaten sollen bei der Planung berücksichtigt werden. Realisiert wurde dies
+mit einer eigenen Planungsansicht im Plugin, basierend auf der
+Ablaufplanverwaltung. Hiermit entfällt die mehrfache Eingabe von kursbezogenen
+Metadaten.
 
-*Kontrolle der Sichtbarkeit*: Die DozentIn soll die Sichtbarkeit jeder Aufzeichnung individuell festlegen können. Dies wird durch eine eigenes Einstellungsmenü in der Kursansicht realisiert. Hier kann die DozentIn pro verfügbarer Vorlesungsaufzeichungen über die Sichtbarkeit entscheiden. Zukünftig soll an dieser Stelle auch entsprechende Distributionskanäle wie z.B. das Lernfunk Portal für jede Aufzeichnung auswählbar sein.
+*Kontrolle der Sichtbarkeit*: Die DozentIn soll die Sichtbarkeit jeder
+Aufzeichnung individuell festlegen können. Dies wird durch eine eigenes
+Einstellungsmenü in der Kursansicht realisiert. Hier kann die DozentIn pro
+verfügbarer Aufzeichung über die Sichtbarkeit entscheiden.


### PR DESCRIPTION
This patch fixes several typos in the readme file. It also removes the
old name “Matterhorn” which has been dropped by the Opencast project
several years ago.