### PR TITLE
Korrektur des Zeitformats

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -623,7 +623,7 @@ class CourseController extends OpencastController
             if($e['id'] == $episode_id) {
                 $e['author'] = $e['author'] !=''? $e['author'] : 'Keine Angaben vorhanden';
                 $e['description'] =$e['description'] !='' ? $e['description']  : 'Keine Beschreibung vorhanden';
-                $e['start'] = date("d.m.Y H:m",strtotime($e['start']));
+                $e['start'] = date("d.m.Y H:i",strtotime($e['start']));
 
                 $cand_episode = $e;
             }

--- a/views/course/_episodelist.php
+++ b/views/course/_episodelist.php
@@ -21,7 +21,6 @@
                 <span class="oce_list_date">
                     <% var date = new Date(episodes[episode]['start'])%>
                     Vom <%= ('0' + date.getDate()).slice(-2)%>.<%= ('0' + (date.getMonth()+1)).slice(-2)%>.<%= date.getFullYear()%>  <%= ('0' + date.getHours()).slice(-2)%>:<%= date.getMinutes()%>
-                    <?//=sprintf(_("Vom %s"),date("d.m.Y H:m",strtotime($item['start'])))?></span>
             </div>
         </a>
     </li>

--- a/views/course/index.php
+++ b/views/course/index.php
@@ -159,7 +159,7 @@
             <div class="oce_emetadata">
                 <h2 class="oce_title"><?= $active['title']?></h2>
                 <ul class="oce_contetlist">
-                    <li><?=$_('Aufzeichnungsdatum : ')?> <?=date("d.m.Y H:m",strtotime($active['start']));?> <?=$_("Uhr")?></li>
+                    <li><?=$_('Aufzeichnungsdatum : ')?> <?=date("d.m.Y H:i",strtotime($active['start']));?> <?=$_("Uhr")?></li>
                     <li><?=$_('Autor : ')?> <?=$active['author'] ? $active['author']  : 'Keine Angaben vorhanden';?></li>
                     <li><?=$_('Beschreibung : ')?> <?=$active['description'] ? $active['description']  : 'Keine Beschreibung vorhanden';?></li>
                 </ul>
@@ -226,7 +226,7 @@
                     </div>
                     <div class="oce_metadatacontainer">
                         <h3 class="oce_metadata"><?=$_('Video wird verarbeitet: ')?> <?= htmlready(mb_convert_encoding($state->mediapackage->title, 'ISO-8859-1', 'UTF-8'))?></h3>
-                        <span class="oce_metadata"><?=sprintf($_("Hochgeladen am %s"),date("d.m.Y H:m",strtotime($state->mediapackage->start)))?></span>
+                        <span class="oce_metadata"><?=sprintf($_("Hochgeladen am %s"),date("d.m.Y H:i",strtotime($state->mediapackage->start)))?></span>
                     </div>
                     <? endif; ?>
             </li>
@@ -251,7 +251,7 @@
                     </div>
                     <div class="oce_metadatacontainer">
                         <h3 class="oce_metadata oce_list_title"><?= $item['title']?> <?=($item['visibility'] != 'false') ? '' : ' (Unsichtbar)'?></h3>
-                        <span class="oce_list_date"><?=sprintf($_("Vom %s"),date("d.m.Y H:m",strtotime($item['start'])))?></span>
+                        <span class="oce_list_date"><?=sprintf($_("Vom %s"),date("d.m.Y H:i",strtotime($item['start'])))?></span>
                     </div>
             </a>
             </li>


### PR DESCRIPTION
Dieser Patch korrigiert das Zeitformat welches momentan
`<Stunde>:<Monat>` dargestellt hat.

This fixes #79