### PR TITLE
Use HTTPS in homepage link

### DIFF
--- a/plugin.manifest
+++ b/plugin.manifest
@@ -7,5 +7,5 @@ studipMaxVersion=4.1
 summary=Vorlesungsaufzeichnung
 category = Inhalte und Aufgabenstellungen
 description=Mit diesem Tool k�nnen Videos aus dem Vorlesungsaufzeichnungssystem (OpenCast) mit einer Stud.IP Veranstaltung verkn�pft werden. Die Aufzeichnungen werden in einem eingebetteten Player in Stud.IP zur Verf�gung gestellt. Dar�berhinaus ist es mit dieser Integration m�glich die komplette Aufzeichnungsplanung f�r eine Veranstaltung abzubilden. Voraussetzung hierf�r sind entsprechende Eintr�ge im Ablaufplan und eine gebuchte Ressource mit einem Opencast Capture-Agent. Vorhandene Medien k�nnen bei Bedarf nachtr�glich �ber die Upload-Funktion zur verkn�pften Series hinzugef�gt werden.
-homepage=http://elan-ev.github.io/studip-opencast-plugin/
+homepage=https://elan-ev.github.io/studip-opencast-plugin/
 screenshot=images/screenshots/studip-opencast.png


### PR DESCRIPTION
This patch switches to HTTPS as protocol for linking the plugin's
homepage.