### PR TITLE
Use correct unit for bitrate

### DIFF
--- a/models/OCCourseModel.class.php
+++ b/models/OCCourseModel.class.php
@@ -250,7 +250,7 @@ class OCCourseModel
                             );
                             $audio_download[$quality] = [
                                 'url' => $track->url,
-                                'info' => round($track->audio->bitrate/1000,1).'kHz'
+                                'info' => round($track->audio->bitrate/1000,1).'kb/s'
                             ];
                         }
                     }


### PR DESCRIPTION
The unit for the sampling rate (kHz) was used to describe the bitrate
which lead to incorrect (and confusingly high) sampling rates to be
displayed.