### PR TITLE
Error when series metadata are empty

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -240,7 +240,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin
 
         if ($GLOBALS['perm']->have_studip_perm('dozent', $course_id)) {
             $series_metadata = OCSeriesModel::getConnectedSeriesDB($course_id);
-            if ($series_metadata[0]['schedule'] == '1') {
+            if ($series_metadata && $series_metadata[0]['schedule'] == '1') {
                 $main->addSubNavigation('scheduler', $scheduler);
             }
         }

--- a/models/OCSeriesModel.php
+++ b/models/OCSeriesModel.php
@@ -25,7 +25,7 @@ class OCSeriesModel
         if ($series = $stmt->fetchAll(PDO::FETCH_ASSOC))
             return $series;
         else
-            return false;
+            return array();
     }
 
     static function getSeminarAndSeriesData()


### PR DESCRIPTION
If the series metadata are empty, users get a warning since the plugin
tries to iterate over a boolean value:

    Warning: Invalid argument supplied for foreach() in
    /var/www/studip/public/plugins_packages/elan-ev/OpenCast/controllers/course.php
    on line 147

This patch ensures to return an empty array instead of false if there
are no data.

*Note that I did not test the patch in action.*