### PR TITLE
Return number_of_chunks not is_infinite()

### DIFF
--- a/classes/OCJob.php
+++ b/classes/OCJob.php
@@ -71,7 +71,7 @@ class OCJob
         $chunks = ceil($this->data['file']['size'] / $config['upload_chunk_size']);
 
         // prevent counting to infinity, might take to long
-        return !is_infinite($chunks) ?: 0;
+        return !is_infinite($chunks) ? $chunks : 0;
     }
 
     /**


### PR DESCRIPTION
Otherwise Opencast says it's READY for more chunks while Stud.IP is waiting to get a COMPLETE status by Opencast. This is either running until your Opencast server dies, PHP max execution time is hit or any database server involved quits the connection.