### PR TITLE
Fix: Editor video insertion button

### DIFF
--- a/controllers/ajax.php
+++ b/controllers/ajax.php
@@ -82,7 +82,7 @@ class AjaxController extends OpencastController
                 : $a['endtime'] < $b['endtime'] ? -1 : 1;
         });
 
-        $this->render_json($series);
+        $this->render_json(array_values($series));
     }
 
     function getepisodes_action($series_id)
@@ -114,7 +114,7 @@ class AjaxController extends OpencastController
             }
         }
 
-        $this->render_json($result);
+        $this->render_json(array_values($result));
     }
 
     /**

--- a/models/OCSeriesModel.php
+++ b/models/OCSeriesModel.php
@@ -45,15 +45,16 @@ class OCSeriesModel
     static function getSeriesForUser($user_id)
     {
         if ($GLOBALS['perm']->have_perm('root', $user_id)) {
-            $stmt = DBManager::get()->prepare("SELECT DISTINCT se.seminar_id, se.config_id, series_id FROM seminar_user AS su
-                JOIN oc_seminar_series AS se ON (su.Seminar_id = se.seminar_id)
+            $stmt = DBManager::get()->prepare("SELECT DISTINCT se.seminar_id, se.config_id, se.series_id
+                FROM oc_seminar_series AS se
                 JOIN oc_seminar_episodes AS ep ON (se.series_id = ep.series_id)
                 WHERE ep.visible != 'invisible'");
             $stmt->execute();
 
             return $stmt->fetchAll(PDO::FETCH_ASSOC);
         } else {
-            $stmt = DBManager::get()->prepare("SELECT DISTINCT se.seminar_id, se.config_id, series_id FROM seminar_user AS su
+            $stmt = DBManager::get()->prepare("SELECT DISTINCT se.seminar_id, se.config_id, se.series_id
+                FROM seminar_user AS su
                 JOIN oc_seminar_series AS se ON (su.Seminar_id = se.seminar_id)
                 JOIN oc_seminar_episodes AS ep ON (se.series_id = ep.series_id)
                 WHERE su.user_id = ?


### PR DESCRIPTION
1. MariaDB requires unambiguous column names even if the values are
   guaranteed to be the same.
2. The script (embed.js) requires the response to be a JSON array,
   not a JSON object.
3. Fixes inefficient SQL query for root user where table that was
   never referenced had been joined.

Resolves #230