### PR TITLE
Add course specific config to prevent downloads, refs #184

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -883,6 +883,50 @@ class CourseController extends OpencastController
 
     }
 
+    function allow_download_action($ticket)
+    {
+        if (
+            check_ticket($ticket)
+            && $GLOBALS['perm']->have_studip_perm('dozent', $this->course_id)
+        ) {
+            CourseConfig::get($this->course_id)->store('OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE', 'yes');
+            $this->flash['messages'] = ['info' => _("Teilnehmer dürfen nun Aufzeichnungen herunterladen.")];
+        }
+
+        $this->redirect('course/index/false');
+    }
+
+    function disallow_download_action($ticket)
+    {
+        if (
+            check_ticket($ticket)
+            && $GLOBALS['perm']->have_studip_perm('dozent', $this->course_id)
+        ) {
+            CourseConfig::get($this->course_id)->store('OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE', 'no');
+            $this->flash['messages'] = ['info' => _("Teilnehmer dürfen nun keine Aufzeichnungen mehr herunterladen.")];
+        }
+
+        $this->redirect('course/index/false');
+    }
+
+    public function isDownloadAllowed()
+    {
+        $courseConfig = CourseConfig::get($this->course_id)->OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE;
+        switch ($courseConfig) {
+            case 'yes':
+                return true;
+
+            case 'no':
+                return false;
+
+            case 'inherit':
+                $globalConfig = Config::get()->OPENCAST_ALLOW_MEDIADOWNLOAD;
+                return $globalConfig;
+        }
+
+        throw new RuntimeException("The course's configuration of OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE contains an unknown value.");
+    }
+
     public static function nice_size_text($size, $precision = 1, $conversion_factor = 1000, $display_threshold = 0.5)
     {
         $possible_sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];

--- a/migrations/029_add_course_config_for_mediadownload.php
+++ b/migrations/029_add_course_config_for_mediadownload.php
@@ -1,0 +1,29 @@
+<?php
+
+class AddCourseConfigForMediadownload extends Migration
+{
+    public function up()
+    {
+        $db = DBManager::get();
+
+        $stmt = $db->prepare('INSERT IGNORE INTO config (field, value, section, type, `range`, mkdate, chdate, description)
+                              VALUES (:name, :value, :section, :type, :range, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), :description)');
+        $stmt->execute([
+            'name'        => 'OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE',
+            'section'     => 'opencast',
+            'description' => 'Wird Nutzern angeboten, Aufzeichnungen herunterzuladen?',
+            'range'       => 'course',
+            'type'        => 'string',
+            'value'       => 'inherit'
+        ]);
+
+        SimpleOrMap::expireTableScheme();
+    }
+
+    public function down()
+    {
+        $db = DBManager::get();
+
+        $db->exec("DELETE FROM config WHERE field = 'OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE'");
+    }
+}

--- a/views/course/_episode.php
+++ b/views/course/_episode.php
@@ -124,7 +124,7 @@ $visibility_text = [
                     </div>
 
                         <div class="ocplayerlink">
-                            <? if (\Config::get()->OPENCAST_ALLOW_MEDIADOWNLOAD) : ?>
+                            <? if ($controller->isDownloadAllowed()) : ?>
                                 <? if (!empty($item['presenter_download'])
                                         || !empty($item['presentation_download'])
                                         || !empty($item['audio_download'])

--- a/views/course/index.php
+++ b/views/course/index.php
@@ -193,6 +193,21 @@ if ($GLOBALS['perm']->have_studip_perm('tutor', $this->course_id)) {
                     : 'video+decline', 'clickable')
             );
         }
+
+        if ($controller->isDownloadAllowed()) {
+            $actions->addLink(
+                $_("Downloads verhindern"),
+                PluginEngine::getLink('opencast/course/disallow_download/' . get_ticket()),
+                new Icon('download+decline', 'clickable')
+            );
+        } else {
+            $actions->addLink(
+                $_("Downloads erlauben"),
+                PluginEngine::getLink('opencast/course/allow_download/' . get_ticket()),
+                new Icon('download+accept', 'clickable')
+            );
+        }
+
     } else {
         $actions->addLink(
             $_('Neue Series anlegen'),


### PR DESCRIPTION
Während zuvor nur ein systemweites Verhindern der Downloads möglich war, darf jede*r Lehrende nun selbst entscheiden, ob er/sie Downloads verhindern möchte.