### PR TITLE
Weglassen von `workflowID` aus Studio-Link

### DIFF
--- a/views/course/index.php
+++ b/views/course/index.php
@@ -141,8 +141,7 @@ if ($GLOBALS['perm']->have_studip_perm('tutor', $this->course_id)) {
                 $actions->addLink($_("Video aufnehmen"),
                     URLHelper::getLink($config['service_url'] . '/studio/index.html', [
                         'cid' => null,
-                        'upload.seriesId'   => $connectedSeries[0]['series_id'],
-                        'upload.workflowId' => $uploadwf->workflow_id
+                        'upload.seriesId' => $connectedSeries[0]['series_id']
                     ]),
                     new Icon('video2', 'clickable'), [
                         'target' => '_blank'


### PR DESCRIPTION
Siehe #245 