### PR TITLE
"Mediendownload verbiteten" schon für Tutoren

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -903,7 +903,7 @@ class CourseController extends OpencastController
     {
         if (
             check_ticket($ticket)
-            && $GLOBALS['perm']->have_studip_perm('dozent', $this->course_id)
+            && $GLOBALS['perm']->have_studip_perm('tutor', $this->course_id)
         ) {
             CourseConfig::get($this->course_id)->store('OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE', 'yes');
             $this->flash['messages'] = ['info' => _("Teilnehmer dürfen nun Aufzeichnungen herunterladen.")];
@@ -916,7 +916,7 @@ class CourseController extends OpencastController
     {
         if (
             check_ticket($ticket)
-            && $GLOBALS['perm']->have_studip_perm('dozent', $this->course_id)
+            && $GLOBALS['perm']->have_studip_perm('tutor', $this->course_id)
         ) {
             CourseConfig::get($this->course_id)->store('OPENCAST_ALLOW_MEDIADOWNLOAD_PER_COURSE', 'no');
             $this->flash['messages'] = ['info' => _("Teilnehmer dürfen nun keine Aufzeichnungen mehr herunterladen.")];


### PR DESCRIPTION
In [views/course/index.php#L115](https://github.com/elan-ev/studip-opencast-plugin/blob/master/views/course/index.php#L115) course administration links are shown if user is at least `tutor`, however the controller action for allow/disallow downloads checked for `dozent`.

A statement from our Stud.IP administration:

> Tutoren können alles was Lehrende können in der Veranstaltung. Sie können nur nicht selber Veranstaltungen anlegen. Es sind auch nicht immer Studierende die Tutoren sind, manchmal auch Mitarbeiter.

Another statement from elearning dept seems to emphasize that:
> Ich denke [...] an [...] hilfsbedürftige Lehrende, die sich von dem/der TutorIn [...] abnehmen lassen und wäre daher eher für erlauben.