### PR TITLE
Remove invalid XML characters

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -73,9 +73,44 @@ const OC = {
             })
         }
 
+        /**
+         * Removes invalid XML characters from a string
+         * source: https://gist.github.com/john-doherty/b9195065884cdbfd2017a4756e6409cc
+         * author: John Doherty, license: MIT
+         * @param {string} str - a string containing potentially invalid XML characters (non-UTF8 characters, STX, EOX etc)
+         * @param {boolean} removeDiscouragedChars - should it remove discouraged but valid XML characters
+         * @return {string} a sanitized string stripped of invalid XML characters
+         */
+        function removeXMLInvalidChars(str, removeDiscouragedChars) {
+
+            // remove everything forbidden by XML 1.0 specifications, plus the unicode replacement character U+FFFD
+            var regex = /((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))/g;
+
+            // ensure we have a string
+            str = String(str || '').replace(regex, '');
+
+            if (removeDiscouragedChars) {
+
+                // remove everything discouraged by XML 1.0 specifications
+                regex = new RegExp(
+                    '([\\x7F-\\x84]|[\\x86-\\x9F]|[\\uFDD0-\\uFDEF]|(?:\\uD83F[\\uDFFE\\uDFFF])|(?:\\uD87F[\\uDF' +
+                    'FE\\uDFFF])|(?:\\uD8BF[\\uDFFE\\uDFFF])|(?:\\uD8FF[\\uDFFE\\uDFFF])|(?:\\uD93F[\\uDFFE\\uD' +
+                    'FFF])|(?:\\uD97F[\\uDFFE\\uDFFF])|(?:\\uD9BF[\\uDFFE\\uDFFF])|(?:\\uD9FF[\\uDFFE\\uDFFF])' +
+                    '|(?:\\uDA3F[\\uDFFE\\uDFFF])|(?:\\uDA7F[\\uDFFE\\uDFFF])|(?:\\uDABF[\\uDFFE\\uDFFF])|(?:\\' +
+                    'uDAFF[\\uDFFE\\uDFFF])|(?:\\uDB3F[\\uDFFE\\uDFFF])|(?:\\uDB7F[\\uDFFE\\uDFFF])|(?:\\uDBBF' +
+                    '[\\uDFFE\\uDFFF])|(?:\\uDBFF[\\uDFFE\\uDFFF])(?:[\\0-\\t\\x0B\\f\\x0E-\\u2027\\u202A-\\uD7FF\\' +
+                    'uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|' +
+                    '(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF]))', 'g');
+
+                str = str.replace(regex, '');
+            }
+
+            return str;
+        }
+
         function createDCCCatalog(terms) {
             var escapeString = function (string) {
-                return new XMLSerializer().serializeToString(new Text(string));
+                return new XMLSerializer().serializeToString(new Text(removeXMLInvalidChars(string, true)));
             };
 
             return '<?xml version="1.0" encoding="UTF-8"?>' +


### PR DESCRIPTION
Sending user input through an XML serializer is not enough;
some characters, which are not allowed in XML are still present,
for instance the vertical tab character.

See for instance: https://stackoverflow.com/q/14665288/2683737
or: https://github.com/sparklemotion/nokogiri/issues/1581#issuecomment-272455205
or: https://www.w3.org/TR/xml11/#sec-starttags

In Opencast, the vertical tab 0x0b causes events with almost
entirely blank meta data shown in Admin UI.
https://github.com/opencast/opencast/issues/2127

This should not notably impact performance, as usually only small strings are processed and Emoji will be mostly untouched.