### PR TITLE
Apply ACLs to new episodes after storing in DB

### DIFF
--- a/models/OCModel.php
+++ b/models/OCModel.php
@@ -570,7 +570,7 @@ class OCModel
             // allow ACL changes right now
             $episode->chdate     = 1;
             $episode->mkdate     = time();
-
+            $is_new = true;
         }
 
         $episode->visible       = $visibility;


### PR DESCRIPTION
Apply Stud.IP-generated ACLs to new episodes in Opencast right
after they have been detected and a reference has been stored
in the Stud.IP database.

In commit 2a08fcde8 we forgot setting ACLs right after storing
detected episodes in the database.
This was probably the cause why some of our Opencast Studio
users reported missing permissions on their produced episodes
right after Opencast published them.

----

The bottom line is the ACL logic is so complicated that I might
miss a point. When I have the time, I'll probably build a chart of
the desired behavior and compare that to the current one.