### PR TITLE
Hochladen für Studierende erfordert Freischaltung des Opencast Inhaltselements unter Admin -> Standort -> Veranstaltungskategorien -> Studiengruppen #406

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -228,9 +228,17 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin
         $studyGroupId = CourseConfig::get($course_id)->OPENCAST_MEDIAUPLOAD_STUDY_GROUP;
 
         if (!empty($studyGroupId)) {
-            $studyGroup = new Navigation($this->_('Zur Studiengruppe'));
-            $studyGroup->setURL(PluginEngine::getURL($this, ['cid' => $$linkedCourseId], 'course/redirect_studygroup/' . $studyGroupId));
-            $main->addSubNavigation('studygroup', $studyGroup);
+            foreach ($GLOBALS['SEM_CLASS'] as $id => $sem_class) {
+                if ($sem_class['name'] == 'Studiengruppen') {
+                    $isActive = $sem_class['modules']['OpenCast']['activated'] || !$sem_class['modules']['OpenCast']['sticky'];
+                    break;
+                }
+            }
+            if ($isActive) {
+                $studyGroup = new Navigation($this->_('Zur Studiengruppe'));
+                $studyGroup->setURL(PluginEngine::getURL($this, ['cid' => $$linkedCourseId], 'course/redirect_studygroup/' . $studyGroupId));
+                $main->addSubNavigation('studygroup', $studyGroup);
+            }
         }
 
         $linkedCourseId = CourseConfig::get($course_id)->OPENCAST_MEDIAUPLOAD_LINKED_COURSE;

--- a/views/course/index.php
+++ b/views/course/index.php
@@ -349,6 +349,17 @@ Helpbar::get()->addLink('Bei Problemen: ' . $GLOBALS['UNI_CONTACT'], 'mailto:' .
     <? endif; ?>
 <? endif; ?>
 
+<? if ($GLOBALS['perm']->have_studip_perm('tutor', $course_id)) : ?>
+    <? foreach ($GLOBALS['SEM_CLASS'] as $sem_class) : ?>
+        <? if ($sem_class['name'] == 'Studiengruppen') : ?>
+            <? if (!$sem_class['modules']['OpenCast']['activated'] && $sem_class['modules']['OpenCast']['sticky']) : ?>
+                <?= MessageBox::info($_('Das Opencast Plugin ist momentan nicht für Studiengruppen aktiv. Wenden Sie sich an einen Admin, um das Problem zu beheben.'));
+                    break; ?>
+            <? endif ?>
+        <? endif ?>
+    <? endforeach ?>
+<? endif ?>
+
 <!--- hidden -->
 <div class="hidden" id="course_id" data-courseId="<?= $course_id ?>"></div>
 <div id="visibility_dialog" style="display: none">


### PR DESCRIPTION
Falls das Opencast Plugin für Studiengruppen deaktiviert ist, wird:
- Der Link "Zur Studiengruppe" ausgeblendet
- Dozenten/Tutoren eine Hinweismeldung angezeigt