### PR TITLE
Ausblenden aus Studiengruppe und institut #410 #412

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -408,4 +408,23 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin
     {
         return 'Opencast';
     }
+
+    /**
+     * Returns whether the plugin may be activated in a certain context.
+     *
+     * @param Range $context
+     * @return bool
+     */
+    public function isActivatableForContext(Range $context)
+    {
+        if (!$GLOBALS['perm']->have_perm('root') &&
+            $context->getRangeType() === 'course' && 
+            $context->getSemClass()['studygroup_mode']) {
+            return false;
+        }
+        if ($context->getRangeType() === 'institute') {
+            return false;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
- Einstellungsmöglichkeit wird aus Einrichtungen komplett entfernt
- Bei Studiengruppen hat nur noch root Einstellungsmöglichkeiten

TODO:
Einstellungsmöglichkeit wird nur ausgeblendet, falls das Plugin deaktiviert ist!
Studenten können das Plugin also immer noch in einer Studiengruppe deaktivieren, falls es aktiviert ist.