### PR TITLE
Hide withdraw consent for admins

### DIFF
--- a/views/course/index.php
+++ b/views/course/index.php
@@ -198,7 +198,7 @@ if ($GLOBALS['perm']->have_studip_perm('tutor', $this->course_id)) {
             }
         }
 
-        if (Config::get()->OPENCAST_SHOW_TOS && !$GLOBALS['perm']->have_perm('root')) {
+        if (Config::get()->OPENCAST_SHOW_TOS && !$GLOBALS['perm']->have_perm('admin')) {
             $actions->addLink(
                 $_('Datenschutzeinwilligung zurückziehen'),
                 $controller->url_for('course/withdraw_tos/' . get_ticket()),


### PR DESCRIPTION
Admins können keine Nutzungsbedingungen akzeptieren. Folglich sollten sie auch den Link zum Zurückziehen, der einfach nichts tut auch nicht sehen.