### PR TITLE
Withdraw TOS only for the user who did

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -250,8 +250,9 @@ class CourseController extends OpencastController
             return $this->redirect('course/index');
         }
 
-        OCTos::deleteBySQL('seminar_id = ?', [
-            $this->course_id
+        OCTos::deleteBySQL('seminar_id = :cid AND user_id = :uid', [
+            ':cid' => $this->course_id,
+            ':uid' => $GLOBALS['user']->id
         ]);
 
         $this->redirect('course/index');


### PR DESCRIPTION
Wenn ein Dozent oder Tutor sein Einverständnis zurück zieht, sollte auch nur sein Einverständnis gelöscht werden. Kann zwar sein, dass dann noch immer Vorlesungen von ihm da rumliegen, aber dann muss er sie halt vorher löschen.