### PR TITLE
Allow ACL changes on stopped, failed WFIs

### DIFF
--- a/classes/lti/OpencastLTI.php
+++ b/classes/lti/OpencastLTI.php
@@ -279,7 +279,7 @@ class OpencastLTI
             // state is ''.
             // Do not continue on failed or stopped WFs! They MUST prevent StudIP
             // from changing ACLs
-            if (!in_array($workflow, ['SUCCEEDED', ''])) {
+            if (!in_array($workflow, ['SUCCEEDED', 'FAILED', 'STOPPED', ''])) {
                 // do not change ACLs if there is a running workflow!
                 return false;
             }


### PR DESCRIPTION
ACLs should be changeable even if the previous workflow
was stopped or failed. Since the Stud.IP Opencast plugin
decided to remove failed workflows from view of the lecutror
it isn't obvious to them why they can't change ALCs.