### PR TITLE
Info für Leser*innen: Kausalzusammenhang

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -100,7 +100,7 @@ class CourseController extends OpencastController
 
         $this->mayWatchEpisodes = $GLOBALS['perm']->have_studip_perm('autor', $this->course_id);
         if (!$this->mayWatchEpisodes) {
-            PageLayout::postInfo($this->_('Sie sind in dieser Veranstaltung nur Leser*in. Sie können die Aufzeichnungen leider nicht ansehen. Wenden Sie sich eventuell an die Lehrenden dieser Veranstaltung!'));
+            PageLayout::postInfo($this->_('Sie sind in dieser Veranstaltung nur Leser*in. Sie können die Aufzeichnungen daher nicht ansehen. Bitte wenden Sie sich an die Lehrenden dieser Veranstaltung!'));
         }
 
         $reload = true;


### PR DESCRIPTION
Zwischen dem Eintrag als Leser*innen und dem Nichtsehen der Videos besteht ein kausaler Zusammenhang,
der mit diesem Commit verdeutlicht wird.
"Eventuell" gestrichen. Wen es stört, der weiß, an wen er sich nun wenden kann und alle anderen werden wegen
dieses Textes nicht anfangen ihren Lehrenden zu schreiben.
Bitte.