### PR TITLE
No params on ApiEventsCl::getAllScheduledEvents()

### DIFF
--- a/cronjobs/refresh_scheduled_events.php
+++ b/cronjobs/refresh_scheduled_events.php
@@ -48,7 +48,7 @@ class RefreshScheduledEvents extends CronJob
 
         // TODO: consider multiple opencast installations
         $api_client = ApiEventsClient::getInstance(1);
-        $events = $api_client->getAllScheduledEvents($scheduled_events['series_id']);
+        $events = $api_client->getAllScheduledEvents();
 
         if (!empty($scheduled_events)) {
             foreach ($scheduled_events as $se) {


### PR DESCRIPTION
ApiEventsClient::getAllScheduledEvents() has no parameters.

Please carefully review and test this. Thank you.