### PR TITLE
fix XSS vulnerability

### DIFF
--- a/controllers/admin.php
+++ b/controllers/admin.php
@@ -24,54 +24,6 @@ class AdminController extends OpencastController
         $this->config = OCConfig::getBaseServerConf();
     }
 
-    public function clear_series_action()
-    {
-        return;
-        set_time_limit(7200);
-
-        if (!$GLOBALS['perm']->have_perm('root')) {
-            throw new AccessDeniedException();
-        }
-
-        $series_client = SeriesClient::getInstance(1);
-        $apiseries     = ApiSeriesClient::getInstance(1);
-
-        $series = $series_client->getJSON('/allSeriesIdTitle.json');
-
-        $acl = '[
-              {
-                "allow": true,
-                "role": "ROLE_USER_ADMIN",
-                "action": "read"
-              },
-              {
-                "allow": true,
-                "role": "ROLE_USER_ADMIN",
-                "action": "write"
-              }
-            ]';
-
-        // set default acl for all series, with override
-        foreach ($series->series as $ser) {
-            $series_id = $ser->identifier;
-
-            echo '<b>' . $ser->title . '</b><br/>';
-            var_dump($apiseries->putJSON('/' . $series_id . '/acl', [
-                'acl'      => $acl,
-                'override' => 'true'
-            ]));
-        }
-
-        echo '<hr><hr>';
-
-        foreach (OCSeminarSeries::findBySQL(1) as $data) {
-            $seminar_id = $data->seminar_id;
-            var_dump($seminar_id);
-            var_dump(OpencastLTI::setAcls($seminar_id));
-        }
-        die;
-    }
-
     public function world_series_action()
     {
         return;

--- a/views/admin/_ca-selection.php
+++ b/views/admin/_ca-selection.php
@@ -4,14 +4,14 @@ $assigned_agents = OCModel::getCAforResource($resource['resource_id']);
 
 
 <td>
-    <?= $resource['name'] ?>
+    <?= htmlReady($resource['name']) ?>
 </td>
 <? if (!empty($assigned_agents)) : ?>
     <td>
-        <?= $assigned_agents['capture_agent'] ?>
+        <?= htmlReady($assigned_agents['capture_agent']) ?>
     </td>
     <td>
-        <?= $assigned_agents['workflow_id'] ?>
+        <?= htmlReady($assigned_agents['workflow_id']) ?>
     </td>
     <? foreach ($agents as $key => $agent) : ?>
         <? if (in_array($agent->name, $assigned_agents)): ?>
@@ -39,7 +39,7 @@ $assigned_agents = OCModel::getCAforResource($resource['resource_id']);
                 <option value="" disabled selected><?= $_('Bitte wählen Sie einen CA.') ?></option>
                 <? foreach ($available_agents as $agent) : ?>
                     <? if (isset($agent)) : ?>
-                        <option value="<?= $agent->name ?>"> <?= $agent->name ?></option>
+                        <option value="<?= $agent->name ?>"> <?= htmlReady($agent->name) ?></option>
                     <? endif; ?>
                 <? endforeach; ?>
             </select>
@@ -60,11 +60,11 @@ $assigned_agents = OCModel::getCAforResource($resource['resource_id']);
                                     in_array('schedule-ng', $definition->tags->tag))
                             ) : ?>
                                 <option value="<?= $definition->id ?>">
-                                    <?= $definition->title ?> (<?= $definition->id ?>)
+                                    <?= htmlReady($definition->title) ?> (<?= htmlReady($definition->id) ?>)
                                 </option>
                             <? elseif ($definition->tags->tag == 'schedule' || $definition->tags->tag == 'schedule-ng') : ?>
                                 <option value="<?= $definition->id ?>">
-                                    <?= $definition->title ?> (<?= $definition->id ?>)
+                                    <?= htmlReady($definition->title) ?> (<?= htmlReady($definition->id) ?>)
                                 </option>
                             <? endif; ?>
                         <? endif; ?>

--- a/views/admin/_config_boolean.php
+++ b/views/admin/_config_boolean.php
@@ -1,6 +1,6 @@
 <div>
     <span <?= $config['required'] ? 'class="required"' : '' ?>>
-        <?= $config['description'] ?>
+        <?= htmlReady($config['description']) ?>
     </span>
 </div>
 

--- a/views/admin/_config_integer.php
+++ b/views/admin/_config_integer.php
@@ -1,6 +1,6 @@
 <label>
     <span <?= $config['required'] ? 'class="required"' : '' ?>>
-        <?= $config['description'] ?>
+        <?= htmlReady($config['description']) ?>
     </span>
 
     <input type="number"

--- a/views/admin/_config_string.php
+++ b/views/admin/_config_string.php
@@ -1,6 +1,6 @@
 <label>
     <span <?= $config['required'] ? 'class="required"' : '' ?>>
-        <?= $config['description'] ?>
+        <?= htmlReady($config['description']) ?>
     </span>
 
     <input type="text"

--- a/views/admin/_endpointoverview.php
+++ b/views/admin/_endpointoverview.php
@@ -14,10 +14,10 @@
             <? if ($endpoint['config_id'] != $show_config_id) continue ?>
             <tr>
                 <td>
-                    <?= $endpoint['service_type'] ?>
+                    <?= htmlReady($endpoint['service_type']) ?>
                 </td>
                 <td>
-                    <?= $endpoint['service_url'] ?>
+                    <?= htmlReady($endpoint['service_url']) ?>
                 </td>
             </tr>
         <? endforeach; ?>

--- a/views/admin/_initial_config.php
+++ b/views/admin/_initial_config.php
@@ -48,7 +48,7 @@
     <fieldset class="collapsable">
         <legend>
             <?= $_('Opencast Server Einstellungen')." (ID: $config_id) - "
-                . $_('OC Version') . ": ". $config[$config_id]['service_version'] .".x" ?>
+                . $_('OC Version') . ": ". htmlReady($config[$config_id]['service_version']) .".x" ?>
         </legend>
 
         <label>

--- a/views/admin/resources.php
+++ b/views/admin/resources.php
@@ -57,7 +57,7 @@ Helpbar::get()->addPlainText(
                     <? foreach ($workflows as $workflow) : ?>
                         <option value="<?= $workflow['id'] ?>" title="<?= $workflow['description'] ?>"
                             <?= ($current_workflow['workflow_id'] == $workflow['id']) ? 'selected' : '' ?>>
-                            <?= $workflow['title'] ?> (<?= $workflow['id'] ?>)
+                            <?= htmlReady($workflow['title']) ?> (<?= htmlReady($workflow['id']) ?>)
                         </option>
                     <? endforeach; ?>
                     <?

--- a/views/course/_download.php
+++ b/views/course/_download.php
@@ -3,7 +3,7 @@ foreach (['presenter' => 'ReferentIn', 'presentation' => 'Bildschirm', 'audio' =
     <? $download_type = $type . '_download' ?>
     <? if ($episode[$download_type]) : ?>
         <div>
-            <h2><?= _($button_text) ?></h2>
+            <h2><?= _(htmlReady($button_text)) ?></h2>
             <? $download_info = array_reverse($episode[$download_type], true) ?>
             <? foreach ($download_info as $quality => $content) : ?>
                 <?= Studip\LinkButton::create(

--- a/views/course/_schedule.php
+++ b/views/course/_schedule.php
@@ -71,12 +71,12 @@
                                 <? $topic = true; ?>
                                 <? $titles[] = my_substr($issue->getTitle(), 0, 80); ?>
                             <? endforeach; ?>
-                            <td><?= $_('Themen: ') . my_substr(implode(', ', $titles), 0, 80) ?></td>
+                            <td><?= $_('Themen: ') . htmlReady(my_substr(implode(', ', $titles), 0, 80)) ?></td>
                         <? else : ?>
                             <? foreach ($issues as $is) : ?>
                                 <? $issue = new Issue(['issue_id' => $is]); ?>
                                 <? $topic = true; ?>
-                                <td><?= my_substr($issue->getTitle(), 0, 80) ?></td>
+                                <td><?= htmlReady(my_substr($issue->getTitle(), 0, 80)) ?></td>
                             <? endforeach; ?>
                         <? endif; ?>
                     <? else: ?>

--- a/views/course/config.php
+++ b/views/course/config.php
@@ -21,7 +21,7 @@
                             <? foreach ($all_series[$id] as $serie) : ?>
                                 <option value='{"config_id":"<?= $id ?>", "series_id":"<?= $serie->id ?>"}'
                                         class="nested-item">
-                                    <?= $serie->dcTitle ?>
+                                    <?= htmlReady($serie->dcTitle) ?>
                                 </option>
                             <? endforeach; ?>
                         </optgroup>

--- a/views/course/workflow.php
+++ b/views/course/workflow.php
@@ -26,7 +26,7 @@ use Studip\Button,
                 <? foreach ($workflows as $workflow) : ?>
                     <option value="<?= $workflow['id'] ?>" title="<?= $workflow['description'] ?>"
                         <?= ($uploadwf['workflow_id'] == $workflow['id']) ? 'selected' : '' ?>>
-                        <?= $workflow['title'] ?> (<?= $workflow['id'] ?>)
+                        <?= htmlReady($workflow['title']) ?> (<?= htmlReady($workflow['id']) ?>)
                     </option>
                 <? endforeach; ?>
             </select>


### PR DESCRIPTION
#511 

- [ ] Rich-Text-Editor
    - Wird wohl über js gehändelt (javascripts/embed.js)
    - Bei meinem Localsystem und dem Testsystem hat die Suche nicht funktioniert, konnte es daher nicht testen
- [x] clear_series_action in admin/controller
    - Wird nicht genutzt, hab ich entfernt
- [x] remove_episode_action
    - Konnte ich nicht reproduzieren
- [x] "Aufzeichnung planen"
- [x] "Medien hochladen"
    -  Der Name wird in einem Textfeld gefiltert angezeigt. Da konnte ich kein XSS anwenden
- [x] Möglicherweise werden Workflownamen und Capture-Agent-Namen ungefiltert ausgegeben
- [x] views nach weiteren Problemstellen durchsucht