### PR TITLE
Remove note about chunk size

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -59,13 +59,6 @@ class Constants {
             'type'        => 'boolean'
         ],
         [
-            'name'        => 'upload_chunk_size',
-            'description' => 'Größe der Chunks für das Hochladen in Byte (aktuell ohne Wirkung)',
-            'value'       => 5000000,
-            'type'        => 'integer'
-        ],
-
-        [
             'name'        => 'time_buffer_overlap',
             'description' => 'Zeitpuffer (in Sekunden) um Überlappungen zu verhindern',
             'value'       => 60,

--- a/constants.php
+++ b/constants.php
@@ -60,7 +60,7 @@ class Constants {
         ],
         [
             'name'        => 'upload_chunk_size',
-            'description' => 'Größe der Chunks für das Hochladen in Byte',
+            'description' => 'Größe der Chunks für das Hochladen in Byte (aktuell ohne Wirkung)',
             'value'       => 5000000,
             'type'        => 'integer'
         ],

--- a/views/course/upload.php
+++ b/views/course/upload.php
@@ -209,11 +209,6 @@ if($vis == false){
                 <p><?= $workflow_text ?: $workflow['workflow_id'] ?></p>
             <? endif ?>
         </label>
-
-        <label>
-            <?= $_('Chunk-Größe für hochgeladene Medien') ?>
-            <p><?= round((float)$config['upload_chunk_size'] / 1024 / 1024, 2) ?> MB</p>
-        </label>
     </section>
 
     <label for="video_upload">


### PR DESCRIPTION
It seems to me that since upload via studip is gone, chunked upload was also removed, [in spite of Opencast supporting that, too](https://stable.opencast.org/docs.html?path=/upload). Since still supported by the backend and occasional issues with people with slow connections, it might be worth implementing and I leave the settings in place.