### PR TITLE
admin-ngevent troubleshooting

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -8,6 +8,7 @@ use Opencast\Models\OCSeminarSeries;
 use Opencast\Models\OCTos;
 use Opencast\Models\OCScheduledRecordings;
 use Opencast\Models\OCUploadStudygroup;
+use Opencast\Models\OCEndpoints;
 use Opencast\LTI\OpencastLTI;
 
 class CourseController extends OpencastController
@@ -885,6 +886,9 @@ class CourseController extends OpencastController
                 PageLayout::postSuccess($this->_('Die Episode wurde zum Entfernen markiert.'));
             } else {
                 PageLayout::postError($this->_('Die Episode konnte nicht zum Entfernen markiert werden.'));
+                if (!OCEndpoints::hasEndpoint(OCConfig::getConfigIdForCourse($this->course_id), 'admin-ngevent')) {
+                    PageLayout::postError($this->_('Um das Problem zu Beheben, muss ein Admin in den OpenCast-Einstellungen auf Übernehmen klicken'));
+                }      
             }
         }
 

--- a/models/OCEndpoints.php
+++ b/models/OCEndpoints.php
@@ -49,6 +49,21 @@ class OCEndpoints extends \SimpleORMap
     }
 
     /**
+     * Check if given config_id has an entry of service_type
+     * 
+     * @param string $config_id
+     * @param string $service_type
+     * @return bool
+     */
+    public static function hasEndpoint($config_id, $service_type)
+    {
+        return self::countBySql(
+            'config_id = ? AND service_type = ?',
+            [$config_id, $service_type]
+        ) > 0;
+    }
+
+    /**
      * Remove passed endpoint from config
      *
      * @param int $config_id


### PR DESCRIPTION
An welcher Stelle und für wen soll die Fehlermeldung angezeigt werden? 
Jetzt wird sie jedem angezeigt, wer eine Episode löschen möchte - relevant wäre es ja nur für Admins?

ggf. könnte man den Endpoint auch automatisch hinzufügen