### PR TITLE
Log media upload and episode deletion

### DIFF
--- a/controllers/ajax.php
+++ b/controllers/ajax.php
@@ -13,7 +13,7 @@ class AjaxController extends OpencastController
     public function logupload_action()
     {
         StudipLog::log('OC_UPLOAD_MEDIA', Request::get('workflow_id'), Request::get('course_id'), Request::get('episode_id'));
-        $this->render_text(Request::get('mediaPackage'));
+        $this->render_text('ok');
     }
 
     public function getseries_action()

--- a/controllers/ajax.php
+++ b/controllers/ajax.php
@@ -10,6 +10,12 @@ class AjaxController extends OpencastController
         $this->render_text($this->_('Ups..'));
     }
 
+    public function logupload_action()
+    {
+        StudipLog::log('OC_UPLOAD_MEDIA', Request::get('workflow_id'), Request::get('course_id'), Request::get('episode_id'));
+        $this->render_text(Request::get('mediaPackage'));
+    }
+
     public function getseries_action()
     {
         $series = OCSeriesModel::getSeriesForUser($GLOBALS['user']->id, Context::getId());

--- a/controllers/course.php
+++ b/controllers/course.php
@@ -880,6 +880,7 @@ class CourseController extends OpencastController
                 throw new AccessDeniedException();
             }
 
+            StudipLog::log('OC_REMOVE_MEDIA', $this->course_id, null, $episode_id);
             $adminng_client = AdminNgEventClient::getInstance();
 
             if ($adminng_client->deleteEpisode($episode_id)) {
@@ -888,7 +889,7 @@ class CourseController extends OpencastController
                 PageLayout::postError($this->_('Die Episode konnte nicht zum Entfernen markiert werden.'));
                 if (!OCEndpoints::hasEndpoint(OCConfig::getConfigIdForCourse($this->course_id), 'admin-ngevent')) {
                     PageLayout::postError($this->_('Um das Problem zu Beheben, muss ein Admin in den OpenCast-Einstellungen auf Übernehmen klicken'));
-                }      
+                }
             }
         }
 
@@ -968,7 +969,7 @@ class CourseController extends OpencastController
         $this->copyAvatarToStudyGroup($course, $studyGroup);
         $this->addAllMembersToStudyGroup($course, $studyGroup);
         $this->setupOpencastInStudyGroup($studyGroup);
-        
+
 
         OCUploadStudygroup::create(
             [
@@ -976,7 +977,7 @@ class CourseController extends OpencastController
                 'studygroup_id' => $studyGroup->getId(),
                 'active' => TRUE
             ]
-        );    
+        );
     }
 
     private function createStudyGroupObject($course)

--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -160,9 +160,9 @@ const OC = {
             })
         }
 
-	function addACL(mediaPackage,acl) {
-	    var acldata = new FormData();
-	    acldata.append('mediaPackage', mediaPackage);
+    function addACL(mediaPackage,acl) {
+        var acldata = new FormData();
+        acldata.append('mediaPackage', mediaPackage);
             acldata.append('flavor', 'security/xacml+episode');
             acldata.append('BODY', new Blob([acl]), 'acl.xml');
 
@@ -228,6 +228,20 @@ const OC = {
             }
         }
 
+        function logUpload(episode_id, mediaPackage, workflowId = "upload") {
+          console.log(mediaPackage);
+          return $.ajax({
+              url: STUDIP.URLHelper.getURL('plugins.php/opencast/ajax/logupload/'),
+              method: "POST",
+              data: {
+                  mediaPackage: mediaPackage,
+                  workflow_id: workflowId,
+                  course_id: STUDIP.URLHelper.parameters.cid,
+                  episode_id: episode_id
+              }
+          })
+        }
+
         function finishIngest(mediaPackage, workflowId = "upload") {
             console.log(mediaPackage);
             return $.ajax({
@@ -246,12 +260,16 @@ const OC = {
                 .then(function (_mediaPackage, _status, resp) {
                     return addDCCCatalog(resp.responseText, terms)
                 })
-		.then(function (_mediaPackage, _status, resp) {
-		    var acl = terms.oc_acl;
-		    return addACL(resp.responseText, acl)
+                .then(function (_mediaPackage, _status, resp) {
+                    var acl = terms.oc_acl;
+                    return addACL(resp.responseText, acl)
                 })
                 .then(function (_mediaPackage, _status, resp) {
                     return uploadTracks(resp.responseText, files, onProgress)
+                })
+                .then(function (_mediaPackage, _status, resp) {
+                    const episode_id = _mediaPackage.documentElement.id;
+                    return logUpload(episode_id, _mediaPackage, workflowId)
                 })
                 .then(function (mediaPackage) {
                     return finishIngest(mediaPackage, workflowId)

--- a/migrations/046_add_remove_media.php
+++ b/migrations/046_add_remove_media.php
@@ -1,5 +1,5 @@
 <?php
-class AddLogEpisode extends Migration
+class AddRemoveMedia extends Migration
 {
 
   static $log_actions = [

--- a/migrations/046_add_remove_media.php
+++ b/migrations/046_add_remove_media.php
@@ -1,0 +1,36 @@
+<?php
+class AddLogEpisode extends Migration
+{
+
+  static $log_actions = [
+      [
+          'name'        => 'OC_REMOVE_MEDIA',
+          'description' => 'Opencast: Episode geloescht',
+          'template'    => '%user loeschte Episode %info in %sem(%affected)',
+          'active'      => 1
+      ],
+  ];
+
+
+  function up()
+  {
+      $db = DBManager::get();
+      $query = $db->prepare("INSERT INTO log_actions (action_id, name, description, info_template, active) VALUES (?, ?, ?, ?, ?)");
+
+      foreach (self::$log_actions as $action) {
+          $query->execute(array(md5($action['name']), $action['name'], $action['description'], $action['template'], $action['active']));
+      }
+  }
+
+  function down()
+  {
+      $db = DBManager::get();
+      $query = $db->prepare("DELETE FROM log_actions WHERE action_id = ?");
+      $query2 = $db->prepare("DELETE FROM log_events WHERE action_id = ?");
+
+      foreach (self::$log_actions as $action) {
+          $query->execute(array(md5($action['name'])));
+          $query2->execute(array(md5($action['name'])));
+      }
+  }
+}


### PR DESCRIPTION
- Since media upload targets the Opencast Admin Server, failed upload logging won't throw any error message
- Logging is useful especially for study group uploads; if a student claims having uploaded something that might have been deleted by someone else
- Upload log can be faked the way it's implemented; a forgery-proof implementation would check stud.ip-side if the media package indeed has been recently created by the current user. But since the user name can't be forged, the risk of that simpler implementation appears to be low enough. Anonymous users get a 403: "message: Sie haben nicht die Berechtigung, diese Aktion auszuführen bzw. diesen Teil des Systems zu betreten."