### PR TITLE
Hide OC icon in course overview if no series set

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -150,7 +150,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
 
         if (!$this->isActivated($course_id)
             || (
-                $visibility['visibility'] == 'invisible'
+                $visibility['visibility'] != 'visible'
                 && !OCPerm::editAllowed($course_id)
             )
         ) {


### PR DESCRIPTION
Icon in der Veranstaltungsübersicht nicht anzeigen, wenn noch keine Serienverknüpfung da ist.

Resolves #577