### PR TITLE
WIP: Use CourseId context, do not guess from series

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -303,8 +303,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
 
     public static function markupOpencast($markup, $matches, $contents)
     {
-        $series_id       = OCModel::getSeriesForEpisode($contents);
-        $course_id       = OCConfig::getCourseIdForSeries($series_id);
+        $course_id       = Context::getId();
         $connectedSeries = OCSeminarSeries::getSeries($course_id);
         $config          = OCConfig::getConfigForCourse($course_id);
 


### PR DESCRIPTION
One Opencast series can be connected to multiple courses.
If we then check the role of the user in that course, we might
discover that the user is not at all in the course that was
guessed from the series resulting in missing permissions
after the LTI login (with no role being set).
Instead of guessing, use the course context ID for embedding
Opencast videos.

Is the assumption right, that there is always a course ID
when an Opencast video is embedded in a block?