### PR TITLE
Prevent duplicate scheduling and series creation

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -662,7 +662,27 @@ const OC = {
         var $pass       = $elem.find('input[type=hidden]');
 
         $pass.val($pass_field.val());
+    },
+
+    /* Display an non dismissible modal preventing the user from undertaking
+    *  further actions in the current browser tab (e.g. until the page reloaded)
+    */
+    lockViewportBeforeReload: function() {
+        $('<div>')
+            .text('Ihre Anfrage wird bearbeitet. Bitte haben Sie einen kleinen Moment Geduld.')
+            .dialog({
+                closeOnEscape: false,
+                modal: true,
+                title: 'In Arbeit'
+            })
+            .parent()
+            .find('.ui-dialog-titlebar')
+            .hide();
     }
 };
 
-window.OC = OC
+window.OC = OC;
+
+$(function() {
+  $(document.body).on('click', '.oc-debounce', OC.lockViewportBeforeReload);
+});

--- a/views/course/_schedule.php
+++ b/views/course/_schedule.php
@@ -150,7 +150,7 @@
                                 </a>
                             <? else : ?>
                                 <? if (date($d['date']) > time()) : ?>
-                                    <a href="<?= $controller->url_for('course/schedule/' . $resource . '/' . 0 . '/' . $date->termin_id) ?>">
+                                    <a href="<?= $controller->url_for('course/schedule/' . $resource . '/' . 0 . '/' . $date->termin_id) ?>" class="oc-debounce">
                                         <?= Icon::create(
                                             'video',
                                             Icon::ROLE_CLICKABLE,

--- a/views/course/index.php
+++ b/views/course/index.php
@@ -324,7 +324,10 @@ if (OCPerm::editAllowed($course_id)) {
             $config_actions->addLink(
                 $_('Neue Series anlegen'),
                 $controller->url_for('course/create_series'),
-                Icon::create('tools')
+                Icon::create('tools'),
+                [
+                    'class' => 'oc-debounce'
+                ]
             );
 
             if ($GLOBALS['perm']->have_perm('root')) {


### PR DESCRIPTION
The most common way our lecturers caused trouble is by repeatedly
clicking the schedule button and the "create new series" link.

Addresses #587