### PR TITLE
Add hint to visibility change dialog

### DIFF
--- a/views/course/index.php
+++ b/views/course/index.php
@@ -416,6 +416,9 @@ Helpbar::get()->addLink('Bei Problemen: ' . Config::get()->OPENCAST_SUPPORT_EMAI
                 </label>
             <? endif ?>
         </fieldset>
+        <p>
+            <?= $_('Das Ändern der Sichtbarkeit dauert bis zu einer Minute. Bis zum Abschluss der Änderung in Opencast gilt die alte Sichtbarkeit.') ?>
+        </p>
 
         <footer data-dialog-button>
             <?= Studip\Button::createAccept(


### PR DESCRIPTION
Changing visibility takes some time (as Opencast has to publish
changed ACLs to the search index for the change to become
effective).

Some users, however expect their changes to be applied immediately.

Before:
![image](https://user-images.githubusercontent.com/2311611/174495798-4b4f830c-0760-4ff8-b69e-813224fada2d.png)

This PR:
![image](https://user-images.githubusercontent.com/2311611/174495908-f548bf5d-9ed1-4371-a0d9-e5516d63d6b5.png)
