### PR TITLE
Allow custom info message texts on upload page

### DIFF
--- a/controllers/admin.php
+++ b/controllers/admin.php
@@ -90,7 +90,13 @@ class AdminController extends OpencastController
 
         // set tos (if any)
         if (Request::get('tos')) {
-            Configuration::setGlobalConfig(OPENCAST_TOS, Request::get('tos'));
+            Configuration::setGlobalConfig('OPENCAST_TOS', Request::get('tos'));
+        }
+        if (Request::get('upload_info_heading')) {
+            Configuration::setGlobalConfig('OPENCAST_UPLOAD_INFO_TEXT_HEADING', Request::get('upload_info_heading'));
+        }
+        if (Request::get('upload_info_body')) {
+            Configuration::setGlobalConfig('OPENCAST_UPLOAD_INFO_TEXT_BODY', Request::get('upload_info_body'));
         }
 
         foreach ($request as $config_id => $config) {

--- a/migrations/047_add_upload_legal_info_conf.php
+++ b/migrations/047_add_upload_legal_info_conf.php
@@ -1,0 +1,41 @@
+<?php
+class AddUploadLegalInfoConf extends Migration
+{
+
+    function up()
+    {
+        $db = DBManager::get();
+
+        $stmt = $db->prepare('INSERT IGNORE INTO config (field, value, section, type, `range`, mkdate, chdate, description)
+                              VALUES (:name, :value, :section, :type, :range, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), :description)');
+        $stmt->execute([
+            'name'        => 'OPENCAST_UPLOAD_INFO_TEXT_HEADING',
+            'section'     => 'opencast',
+            'description' => 'Infotext, der auf der Hochladeseite gezeigt wird (Überschrift)',
+            'range'       => 'global',
+            'type'        => 'string',
+            'value'       => 'Laden Sie nur Medien hoch, an denen Sie das Nutzungsrecht besitzen!'
+        ]);
+        $stmt->execute([
+            'name'        => 'OPENCAST_UPLOAD_INFO_TEXT_BODY',
+            'section'     => 'opencast',
+            'description' => 'Infotext, der auf der Hochladeseite gezeigt wird',
+            'range'       => 'global',
+            'type'        => 'string',
+            'value'       => '- Nach §60 UrhG dürfen nur maximal 5-minütige Sequenzen aus urheberrechtlich geschützten Filmen oder Musikaufnahmen'
+                             . ' bereitgestellt werden, sofern diese einen geringen Umfang des Gesamtwerkes ausmachen.'
+                             . '- [§60 UrhG Zusammenfassung]https://elan-ev.de/themen_p60.php'
+                             . '- Medien, bei denen Urheberrechtsverstöße vorliegen, werden ohne vorherige Ankündigung umgehend gelöscht.'
+        ]);
+
+        SimpleOrMap::expireTableScheme();
+    }
+
+    function down()
+    {
+        $db = DBManager::get();
+
+        $db->exec("DELETE FROM config WHERE field IN ('OPENCAST_UPLOAD_INFO_TEXT_HEADING', 'OPENCAST_UPLOAD_INFO_TEXT_BODY')");
+    }
+
+}

--- a/views/admin/_initial_config.php
+++ b/views/admin/_initial_config.php
@@ -34,6 +34,22 @@
             <? endif ?>
 
             <label>
+                <?= $_('Infotext auf der Hochladeseite (Überschrift)') ?>
+                <?= I18N::textarea('upload_info_heading', new I18NString(\Config::get()->OPENCAST_UPLOAD_INFO_TEXT_HEADING, null, [
+                        'object_id' => 2,
+                        'field' => 'upload_info_heading'
+                    ]), ['class' => 'add_toolbar wysiwyg']) ?>
+            </label>
+
+            <label>
+                <?= $_('Infotext auf der Hochladeseite') ?>
+                <?= I18N::textarea('upload_info_body', new I18NString(\Config::get()->OPENCAST_UPLOAD_INFO_TEXT_BODY, null, [
+                        'object_id' => 3,
+                        'field' => 'upload_info_body'
+                    ]), ['class' => 'add_toolbar wysiwyg']) ?>
+            </label>
+
+            <label>
                 <?= $_('In der Datenbank verwendete Konfigurationen (IDs): ') ?>
                 <?
                 $counter = 0;

--- a/views/course/upload.php
+++ b/views/course/upload.php
@@ -250,14 +250,8 @@ if($vis == false){
     </div>
 
     <?= MessageBox::info(
-        $_('Laden Sie nur Medien hoch, an denen Sie das Nutzungsrecht besitzen!'),
-        [
-            $_('Nach §60 UrhG dürfen nur maximal 5-minütige Sequenzen aus urheberrechtlich geschützten Filmen oder Musikaufnahmen bereitgestellt werden, sofern diese einen geringen Umfang des Gesamtwerkes ausmachen.'),
-            '<a href="https://elan-ev.de/themen_p60.php" target="_blank">' .
-            $_('§60 UrhG Zusammenfassung') .
-            '</a>',
-            $_('Medien, bei denen Urheberrechtsverstöße vorliegen, werden ohne vorherige Ankündigung umgehend gelöscht.')
-        ]
+        formatReady(Config::get()->OPENCAST_UPLOAD_INFO_TEXT_HEADING),
+        array_map('formatReady', explode("\n-", preg_replace('/^- *?/', '', Config::get()->OPENCAST_UPLOAD_INFO_TEXT_BODY)))
     ) ?>
 
     <footer>


### PR DESCRIPTION
- Lawyers assessment appears to vary on every university
- 2 new config variables:
    - OPENCAST_UPLOAD_INFO_TEXT_HEADING,
    - OPENCAST_UPLOAD_INFO_TEXT_BODY

Before:

![image](https://user-images.githubusercontent.com/2311611/174499647-27977735-ab41-40c6-baf6-9b9e7be8fd04.png)

With PR:

![image](https://user-images.githubusercontent.com/2311611/174499615-f026c364-8901-4102-90f8-162ee82a5e1a.png)
