### PR TITLE
Allow downloading supplemental material, remove tag filter, drop AVI format download

### DIFF
--- a/views/course/_download.php
+++ b/views/course/_download.php
@@ -7,7 +7,7 @@ foreach (['presenter' => 'ReferentIn', 'presentation' => 'Bildschirm', 'audio' =
             <? $download_info = array_reverse($episode[$download_type], true) ?>
             <? foreach ($download_info as $quality => $content) : ?>
                 <?= Studip\LinkButton::create(
-                    $content['info'] . '  (' . CourseController::nice_size_text($quality) . ')',
+                    $content['info'] . ( $quality > 0 ? '  (' . CourseController::nice_size_text($quality) . ')' : '' ),
                     URLHelper::getURL($content['url']),
                     ['target' => '_blank', 'class' => 'download ' . $type]
                 ); ?>

--- a/views/course/_download.php
+++ b/views/course/_download.php
@@ -1,5 +1,5 @@
 <?php
-foreach (['presenter' => 'ReferentIn', 'presentation' => 'Bildschirm', 'audio' => 'Audio'] as $type => $button_text) :?>
+foreach (['presenter' => 'ReferentIn', 'presentation' => 'Bildschirm', 'audio' => 'Audio', 'supplemental' => 'Materialien'] as $type => $button_text) :?>
     <? $download_type = $type . '_download' ?>
     <? if ($episode[$download_type]) : ?>
         <div>


### PR DESCRIPTION
- allow download presentation audio
- correctly calculate sizes of files offered for download
- use more images as preview fallback images
- display supplemental material for download:
    - BBB sends shared notes (which then can be imported into an Etherpad and work can continue there) to OC
    - BBB sends slides to OC
    - Subtitles can be downloaded, too

**Breaking changes**:

- **allow downloading no matter which Tag**
- **drop AVI format for download (who is still using that??)**

Before this change:

![image](https://user-images.githubusercontent.com/2311611/175377239-0bfcb2f0-1c48-4f33-a4d4-f66a6eff97c5.png)


After this change:

![image](https://user-images.githubusercontent.com/2311611/175377526-aa771d05-f034-4bfe-b2b9-3cb92813ee5c.png)
