### PR TITLE
Relabel upload video options

### DIFF
--- a/views/course/upload.php
+++ b/views/course/upload.php
@@ -224,19 +224,7 @@ if($vis == false){
     </ul>
 
     <div>
-        <?= LinkButton::createAdd($_('Aufzeichnung des/der Vortragende*n hinzufügen'), null, ['class' => 'oc-media-upload-add', 'data-flavor' => 'presenter/source']) ?>
-        <input type="file" class="video_upload" data-flavor="presenter/source"
-               accept=".avi,.mkv,.mp4,.webm,.mov,.ogg,.ogv,video/mp4,video/x-m4v,video/webm,video/ogg,video/mpeg,video/*">
-        <div style="display:none" class="invalid_media_type_warning">
-          <?= MessageBox::error(
-              $_('Die gewählte Datei kann von Opencast nicht verarbeitet werden.'),
-              [
-                  $_('Unterstützte Formate sind .mkv, .avi, .mp4, .mpeg, .webm, .mov, .ogv, .ogg, .flv, .f4v, .wmv, .asf, .mpg, .mpeg, .ts, .3gp und .3g2.')
-              ]
-          ) ?>
-        </div>
-
-        <?= LinkButton::createAdd($_('Aufzeichnung der Folien hinzufügen'), null, ['class' => 'oc-media-upload-add', 'data-flavor' => 'presentation/source']) ?>
+        <?= LinkButton::createAdd($_('Screencast hinzufügen'), null, ['class' => 'oc-media-upload-add', 'data-flavor' => 'presentation/source']) ?>
         <input type="file" class="video_upload" data-flavor="presentation/source"
                accept=".avi,.mkv,.mp4,.webm,.mov,.ogg,.ogv,video/mp4,video/x-m4v,video/webm,video/ogg,video/mpeg,video/*">
         <div style="display:none" class="invalid_media_type_warning">
@@ -247,6 +235,20 @@ if($vis == false){
               ]
            ) ?>
          </div>
+         <p><?= $_('Screencasts bestehend überwiegend aus Präsentationsfolien oder statischen Bildinhalten. Folienwechsel und Text sollen erkannt werden.') ?></p>
+
+         <?= LinkButton::createAdd($_('Kamera-Aufzeichung hinzufügen'), null, ['class' => 'oc-media-upload-add', 'data-flavor' => 'presenter/source']) ?>
+         <input type="file" class="video_upload" data-flavor="presenter/source"
+                accept=".avi,.mkv,.mp4,.webm,.mov,.ogg,.ogv,video/mp4,video/x-m4v,video/webm,video/ogg,video/mpeg,video/*">
+         <div style="display:none" class="invalid_media_type_warning">
+           <?= MessageBox::error(
+               $_('Die gewählte Datei kann von Opencast nicht verarbeitet werden.'),
+               [
+                   $_('Unterstützte Formate sind .mkv, .avi, .mp4, .mpeg, .webm, .mov, .ogv, .ogg, .flv, .f4v, .wmv, .asf, .mpg, .mpeg, .ts, .3gp und .3g2.')
+               ]
+           ) ?>
+         </div>
+         <p><?= $_('Kamera-Video, oder Video das allein oder parallel zum Screencast wiedergegeben werden soll und überwiegend nicht-textliche Bild-Inhalte enthält.') ?></p>
     </div>
 
     <?= MessageBox::info(


### PR DESCRIPTION
- "Aufzeichnung der Votragsfolien"
  Nobody gets this right. Some try to upload PPTs and PDFs directly,
  others simply skip this. So we relabel this to "Screencast"
- "Aufzeichnung des Votragenden"
  Ends up as the default option for most screencasts as lecturors
  think if their voice is in, it's the correct option.
  Clarify that this option is for camera recordings of non-textual
  content.
- Move the screencast option to the first place as most uploads
  are actually screencasts (presentation + voice)

Before:
![Screenshot from 2022-07-02 23-53-03](https://user-images.githubusercontent.com/2311611/177017927-1577d464-3cc2-4c7a-a2c1-356fbbea3c9a.png)

With this PR:
![Screenshot from 2022-07-02 23-56-18](https://user-images.githubusercontent.com/2311611/177017933-a519daf5-b22a-47d4-8d3c-272cda2259ca.png)

