### PR TITLE
Show video duration in course video list

### DIFF
--- a/views/course/_episode.php
+++ b/views/course/_episode.php
@@ -155,6 +155,12 @@ $sort_orders = Pager::getSortOptions();
                                     <?= $item['author'] ? htmlReady($item['author']) : 'Keine Angaben vorhanden' ?>
                                 </li>
                                 <li>
+                                    <?= $_('Spieldauer:') ?>
+                                    <?= $item['duration'] ? htmlReady(
+                                          DateTime::createFromFormat('s', round($item['duration']/1000))->format('H:i:s')
+                                      ) : 'Spieldauer wurde nicht ermittelt' ?>
+                                </li>
+                                <li>
                                     <?= $_('Beschreibung:') ?>
                                     <?= $item['description'] ? htmlReady($item['description']) : 'Keine Beschreibung vorhanden' ?>
                                 </li>


### PR DESCRIPTION
Die Anzeige Wiedergabedauer/Spiellänge/duration/length eines Videos ist
dann besonders nützlich, wenn ein Kurs viele unterschiedlich lange
Videos anbietet.

Vorher:
![Screenshot from 2022-07-03 00-29-08](https://user-images.githubusercontent.com/2311611/177017908-3f29d1c7-9a16-4de6-aa99-861a08d49c4d.png)

Danach:
![Screenshot from 2022-07-03 00-30-04](https://user-images.githubusercontent.com/2311611/177017910-569c3528-c278-41d8-bc98-0e51e74ab802.png)


Resolves #509