### PR TITLE
Use engage-player publication channel

### DIFF
--- a/classes/OCRestClient/ApiEventsClient.php
+++ b/classes/OCRestClient/ApiEventsClient.php
@@ -284,8 +284,14 @@ class ApiEventsClient extends OCRestClient
             'author'        => is_array($episode->presenter) ? implode(', ', $episode->presenter) : $episode->creator,
             'has_previews'  => false
         ];
+        $engage_publication = null;
+        foreach ($episode->publications as $publication) {
+            if ($publication->channel === 'engage-player') {
+                $engage_publication = $publication;
+            }
+        }
 
-        if (!empty($episode->publications[0]->attachments)) {
+        if (!empty($engage_publication->attachments)) {
             $presentation_preview  = false;
             $preview               = false;
             $presenter_download    = [];
@@ -294,7 +300,7 @@ class ApiEventsClient extends OCRestClient
             $annotation_tool       = false;
             $duration              = 0;
 
-            foreach ((array) $episode->publications[0]->attachments as $attachment) {
+            foreach ((array) $engage_publication->attachments as $attachment) {
                 if ($attachment->flavor === "presenter/search+preview" || $attachment->type === "presenter/search+preview") {
                     $preview = $attachment->url;
                 }
@@ -303,7 +309,7 @@ class ApiEventsClient extends OCRestClient
                 }
             }
 
-            foreach ($episode->publications[0]->media as $track) {
+            foreach ($engage_publication->media as $track) {
                 $parsed_url = parse_url($track->url);
 
                 if ($track->flavor === 'presenter/delivery') {


### PR DESCRIPTION
Use the engage-player publication channel when fetching published
assets from Opencast.

Resolves #614