### PR TITLE
Add episode refresh button (to purge cache)

### DIFF
--- a/controllers/course.php
+++ b/controllers/course.php
@@ -923,6 +923,18 @@ class CourseController extends OpencastController
         $this->redirect('course/index/false');
     }
 
+    public function refresh_episode_action($ticket, $episode_id)
+    {
+        OCPerm::checkEdit($this->course_id);
+
+        if (check_ticket($ticket)) {
+            $cache_key = 'sop/episodes/' . $episode_id;
+            \StudipCacheFactory::getCache()->expire($cache_key);
+        }
+
+        $this->redirect('course/index/false');
+    }
+
     public static function nice_size_text($size, $precision = 1, $conversion_factor = 1000, $display_threshold = 0.5)
     {
         $possible_sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];

--- a/stylesheets/oc.less
+++ b/stylesheets/oc.less
@@ -265,6 +265,7 @@ textarea.oc_input:focus {
 .button.ocextern::before,
 .button.oc_editor::before,
 .button.oc_delete::before,
+.button.oc_refresh::before,
 .button.oc_feedback::before,
 .button.oc_download_dialog::before,
 .button.ocspecial::before {
@@ -377,6 +378,14 @@ textarea.oc_input:focus {
 
 .button.oc_delete:hover {
     .icon('before', 'trash', 'info_alt');
+}
+
+.button.oc_refresh {
+    .icon('before', 'refresh', 'clickable');
+}
+
+.button.oc_refresh:hover {
+    .icon('before', 'refresh', 'info_alt');
 }
 
 .button.oc_download_dialog {
@@ -839,4 +848,3 @@ iframe.oc_courseware {
 .oc_italic {
     font-style: italic;
 }
-

--- a/views/course/_episode.php
+++ b/views/course/_episode.php
@@ -232,6 +232,14 @@ $sort_orders = Pager::getSortOptions();
                                     </div>
                                 <? endif ?>
 
+                                <?= Studip\LinkButton::create(
+                                    $_('Metadaten neu laden'),
+                                    $controller->url_for('course/refresh_episode/' . get_ticket() . '/' . $item['id']),
+                                    [
+                                        'class'   => 'oc_refresh',
+                                        'title'   => $_('Metadaten von Opencast aktualisieren')
+                                    ]
+                                ); ?>
 
                                 <? if (OCPerm::editAllowed($course_id)) : ?>
                                     <?= Studip\LinkButton::create(


### PR DESCRIPTION
Our Opencast workflows now first create an engage publication very quickly with only a limited set of features and later create the preview/internal publication for the Opencast editor.

However after creating the engage publication, episode data is cached for about 24h and our lecturors are looking for the cutting button.

This PR adds a "Metdaten aktualisieren" button which will purge/ expire the cached data.

<img width="1213" alt="Screenshot 2022-10-14 at 14 42 38" src="https://user-images.githubusercontent.com/2311611/195849643-2a8cb520-5e3a-408e-996e-981159dd0c91.png">
