### PR TITLE
Ask user to wait when connecting series and mass schedule

### DIFF
--- a/views/course/_schedule.php
+++ b/views/course/_schedule.php
@@ -215,7 +215,7 @@
             </tfoot>
         </table>
         <div>
-            <?= Button::createAccept($_('Übernehmen'), ['title' => $_('Änderungen übernehmen')]); ?>
+            <?= Button::createAccept($_('Übernehmen'), ['title' => $_('Änderungen übernehmen'), 'class' => 'oc-debounce']); ?>
             <?= LinkButton::createCancel($_('Abbrechen'), $controller->url_for('course/scheduler')); ?>
         </div>
     </form>

--- a/views/course/config.php
+++ b/views/course/config.php
@@ -36,7 +36,7 @@
 
 
     <footer data-dialog-button>
-        <?= Button::createAccept($_('Übernehmen'), ['title' => $_('Änderungen übernehmen')]); ?>
+        <?= Button::createAccept($_('Übernehmen'), ['title' => $_('Änderungen übernehmen'), 'class' => 'oc-debounce']); ?>
         <?= LinkButton::createCancel($_('Abbrechen'), $controller->url_for('course/index')); ?>
     </footer>
 </form>


### PR DESCRIPTION
The schedule-delay made our users press reload which caused duplicate scheduled events. Also, adding series to courses can take a considerable amount of time.