### PR TITLE
Allow scheduled events to be shorter than lecture

### DIFF
--- a/classes/OCRestClient/SchedulerClient.php
+++ b/classes/OCRestClient/SchedulerClient.php
@@ -137,12 +137,23 @@ class SchedulerClient extends OCRestClient
         $event = OCScheduledRecordings::find($event_id);
         $date  = CourseDate::find($termin_id);
 
-        if ($date->date != $event->start) {
+        // if start is after end, swap both of them
+        // (slider ending might have been moved before its starting point)
+        if ($event->start > $event->end) {
+            $new_start = $event->end;
+            $event->end = $event->start;
+            $event->start = $new_start;
+            $event->store();
+        }
+
+        // do not allow scheduling before the beginning of the lecture slot
+        if ($date->date > $event->start) {
             $event->start = $date->date;
             $event->store();
         }
 
-        if ($date->end_time != $event->end) {
+        // do not allow scheduling after the end of the lecture slot
+        if ($date->end_time < $event->end) {
             $event->end = $date->end_time;
             $event->store();
         }


### PR DESCRIPTION
Events can be shortened by a slider in the UI. However, for this to work, the Scheduler Client also has to accept these shorter times.

![Screenshot from 2023-01-17 17-41-34](https://user-images.githubusercontent.com/2311611/212967824-2ec3f45c-9759-4ddd-9d64-37c5c9d9d02e.png)

See
https://github.com/elan-ev/studip-opencast-plugin/commit/0508390ad8981abab8869557c425e2dc7825ae12#r96509687