### PR TITLE
Implementation of palylist_seminar_video visibility with timestamps - #662

### DIFF
--- a/assets/css/opencast.scss
+++ b/assets/css/opencast.scss
@@ -532,6 +532,32 @@ h2.oc--loadingbar, .oc--loadingbar-title {
     border-bottom: 1px solid $base_color;
 }
 
+.oc--timestamp-input {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    button {
+        margin-top: .5ex;
+        padding: 5px;
+        border: 1px solid #c5c7ca;
+        background-color: transparent;
+        cursor: pointer;
+
+        &:hover {
+            background-color: $light-gray-color-20;
+        }
+
+        &.oc--trash-button {
+            img {
+                vertical-align: middle;
+                width: 18px;
+                height: 18px;
+            }
+        }
+    }
+}
+
 .oc--datetime-input {
     display: block;
     margin-top: .5ex;

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -356,7 +356,7 @@ class Videos extends UPMap
                 ];
             }
         }
-        return [];
+        return null;
     }
 
     /**

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -92,12 +92,27 @@ class Videos extends UPMap
      */
     public static function getPlaylistVideos($playlist_id, $filters)
     {
+        global $perm;
+
+        $sql = ' INNER JOIN oc_playlist_video AS opv ON (opv.playlist_id = :playlist_id AND opv.video_id = id)';
+        $where = ' WHERE 1 ';
+        $params = [':playlist_id' => $playlist_id];
+
+        if (!(empty($cid) || $perm->have_perm('dozent'))) {
+            $sql .= ' INNER JOIN oc_playlist_seminar AS ops ON (ops.seminar_id = :cid AND ops.playlist_id = opv.playlist_id)'.
+                    ' LEFT JOIN oc_playlist_seminar_video AS opsv ON (opsv.playlist_seminar_id = ops.id AND opsv.video_id = opv.video_id)';
+            
+            $where = ' WHERE opsv.visibility IS NULL AND opsv.visible_timestamp IS NULL AND ops.visibility = "visible"
+                       OR opsv.visibility = "visible" AND opsv.visible_timestamp IS NULL
+                       OR opsv.visible_timestamp >= NOW() ';
+            
+            $params[':cid'] = $filters->getCourseId();
+        }
+
         $query = [
-            'sql'   => ' INNER JOIN oc_playlist_video AS opv ON (opv.playlist_id = :playlist_id AND opv.video_id = id)',
-            'where' => ' WHERE 1 ',
-            'params' => [
-                ':playlist_id' => $playlist_id
-            ]
+            'sql'   => $sql,
+            'where' => $where,
+            'params' => $params
         ];
 
         return self::getFilteredVideos($query, $filters);
@@ -281,7 +296,7 @@ class Videos extends UPMap
         return self::findOneBySQL('id = ?', [$id]);
     }
 
-    public function toSanitizedArray()
+    public function toSanitizedArray($cid = '', $playlist_id = '')
     {
         $data = $this->toArray();
 
@@ -303,6 +318,7 @@ class Videos extends UPMap
 
         $data['perm'] = $this->getUserPerm($user_id);
         $data['playlists'] = $this->getPlaylists();
+        $data['seminar_visibility'] = $this->getSeminarVisibility($cid, $playlist_id);
 
         $data['tags'] = $this->tags->toArray();
 
@@ -321,6 +337,26 @@ class Videos extends UPMap
         }
 
         return $playlists;
+    }
+
+    private function getSeminarVisibility($cid, $playlist_id)
+    {
+        if (!empty($cid) && !empty($playlist_id)) {
+            $psv = PlaylistSeminarVideos::findOneBySQL(
+                "LEFT JOIN oc_playlist_seminar AS ops ON ops.id = playlist_seminar_id
+                WHERE video_id = ?
+                AND playlist_id = ?
+                AND seminar_id = ?", 
+                [$this->id, $playlist_id, $cid]);
+            
+            if (!empty($psv)) {
+                return [
+                    'visibility' => $psv->getValue('visibility'),
+                    'visible_timestamp' => $psv->getValue('visible_timestamp')
+                ];
+            }
+        }
+        return [];
     }
 
     /**

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -98,13 +98,13 @@ class Videos extends UPMap
         $where = ' WHERE 1 ';
         $params = [':playlist_id' => $playlist_id];
 
-        if (!(empty($cid) || $perm->have_perm('dozent'))) {
+        if (!(empty($filters->getCourseId()) || $perm->have_perm('dozent'))) {
             $sql .= ' INNER JOIN oc_playlist_seminar AS ops ON (ops.seminar_id = :cid AND ops.playlist_id = opv.playlist_id)'.
                     ' LEFT JOIN oc_playlist_seminar_video AS opsv ON (opsv.playlist_seminar_id = ops.id AND opsv.video_id = opv.video_id)';
             
             $where = ' WHERE opsv.visibility IS NULL AND opsv.visible_timestamp IS NULL AND ops.visibility = "visible"
                        OR opsv.visibility = "visible" AND opsv.visible_timestamp IS NULL
-                       OR opsv.visible_timestamp >= NOW() ';
+                       OR opsv.visible_timestamp < NOW() ';
             
             $params[':cid'] = $filters->getCourseId();
         }

--- a/lib/RouteMap.php
+++ b/lib/RouteMap.php
@@ -115,7 +115,7 @@ class RouteMap
     }
 
     /**
-     * Routes called by opencast vith token
+     * Routes called by opencast with token
      */
     public function opencastRoutes()
     {

--- a/lib/Routes/Playlist/PlaylistVideoList.php
+++ b/lib/Routes/Playlist/PlaylistVideoList.php
@@ -53,18 +53,7 @@ class PlaylistVideoList extends OpencastController
 
         $ret = [];
         foreach ($videos['videos'] as $video) {
-            $ret_video = $video->toSanitizedArray();
-            $psv = PlaylistSeminarVideos::findOneBySQL(
-                "LEFT JOIN oc_playlist_seminar AS ops ON ops.id = playlist_seminar_id
-                WHERE video_id = ?
-                AND playlist_id = ?
-                AND seminar_id = ?", [$video->id, $playlist->id, $params['cid']]);
-            if (!empty($psv)) {
-                $ret_video['playlist_seminar'] = [];
-                $ret_video['playlist_seminar']['visibility'] = $psv->getValue('visibility');
-                $ret_video['playlist_seminar']['visible_timestamp'] = $psv->getValue('visible_timestamp');
-            }
-            $ret[] = $ret_video;
+            $ret[] = $video->toSanitizedArray($params['cid'], $playlist->id);
         }
 
         return $this->createResponse([

--- a/lib/Routes/Video/VideoUpdate.php
+++ b/lib/Routes/Video/VideoUpdate.php
@@ -70,18 +70,18 @@ class VideoUpdate extends OpencastController
             unset($event['tags']);
         }
 
-        if (isset($event['from_cid']) && isset($event['from_playlist'])) {
-            $playlist = Playlists::findOneByToken($event['from_playlist']);
+        if (isset($event['cid']) && isset($event['playlist_token'])) {
+            $playlist = Playlists::findOneByToken($event['playlist_token']);
             if (!empty($playlist)) {
-                $playlistSeminar = PlaylistSeminars::findOneBySQL('seminar_id = ? AND playlist_id = ?', [$event['from_cid'], $playlist->id]);
+                $playlistSeminar = PlaylistSeminars::findOneBySQL('seminar_id = ? AND playlist_id = ?', [$event['cid'], $playlist->id]);
                 if (!empty($playlistSeminar)) {
                     PlaylistSeminarVideos::deleteBySQL('playlist_seminar_id = ? AND video_id = ?', [$playlistSeminar->id, $video->id]);
-                    if (isset($event['playlist_seminar'])) {
+                    if (isset($event['seminar_visibility'])) {
                         $pvs = new PlaylistSeminarVideos();
                         $pvs->setValue('playlist_seminar_id', $playlistSeminar->id);
                         $pvs->setValue('video_id', $video->id);
-                        $pvs->setValue('visibility', $event['playlist_seminar']['visibility']);
-                        $pvs->setValue('visible_timestamp', $event['playlist_seminar']['visible_timestamp']);
+                        $pvs->setValue('visibility', $event['seminar_visibility']['visibility']);
+                        $pvs->setValue('visible_timestamp', $event['seminar_visibility']['visible_timestamp']);
                         $pvs->store();
                     }
                 }

--- a/migrations/066_add_visible_timestamp.php
+++ b/migrations/066_add_visible_timestamp.php
@@ -1,0 +1,28 @@
+<?php
+
+class AddVisibleTimestamp extends Migration
+{
+    public function description()
+    {
+        return 'Add timestamp to make video visible for course';
+    }
+
+    public function up()
+    {
+        $db = DBManager::get();
+
+        $db->exec("ALTER TABLE `oc_playlist_seminar_video`
+            ADD COLUMN `visible_timestamp` timestamp DEFAULT NULL");
+
+        SimpleOrMap::expireTableScheme();
+    }
+
+    public function down()
+    {
+        $db = DBManager::get();
+
+        $db->exec("ALTER TABLE `oc_playlist_seminar_video` DROP COLUMN `visible_timestamp`");
+
+        SimpleOrMap::expireTableScheme();
+    }
+}

--- a/vueapp/components/Videos/Actions/VideoEdit.vue
+++ b/vueapp/components/Videos/Actions/VideoEdit.vue
@@ -93,7 +93,12 @@
                             <span v-translate>
                                 Zeitstempel für die Sichtbarkeit
                             </span>
-                            <input class="oc--datetime-input" type="datetime-local" name="visibilityDate" id="visibilityDate" v-model="visible_timestamp" @change="checkVisibility">
+                            <div class="oc--timestamp-input">
+                                <input class="oc--datetime-input" type="datetime-local" name="visibilityDate" id="visibilityDate" v-model="visible_timestamp" @change="checkVisibility">
+                                <button class="oc--trash-button" type="button" @click="visible_timestamp=null">
+                                    <studip-icon shape="trash" role="clickable"/>
+                                </button>
+                            </div>
                         </label>
                     </fieldset>
                 </form>
@@ -105,13 +110,15 @@
 <script>
 import { mapGetters } from "vuex";
 import StudipDialog from '@studip/StudipDialog';
+import StudipIcon from '@/components/Studip/StudipIcon'
 import TagBar from '@/components/TagBar.vue';
 
 export default {
     name: "VideoEdit",
 
     components: {
-        StudipDialog, TagBar
+        StudipDialog, TagBar,
+        StudipIcon
     },
 
     data() {

--- a/vueapp/components/Videos/Actions/VideoEdit.vue
+++ b/vueapp/components/Videos/Actions/VideoEdit.vue
@@ -89,7 +89,7 @@
                             </section>
                         </label>
 
-                        <label>
+                        <label v-if="isCourse">
                             <span v-translate>
                                 Zeitstempel für die Sichtbarkeit
                             </span>

--- a/vueapp/components/Videos/VideosList.vue
+++ b/vueapp/components/Videos/VideosList.vue
@@ -61,7 +61,7 @@
 
             <ul class="oc--episode-list--small" v-else>
                 <VideoCard
-                    v-for="event in videos_visible"
+                    v-for="event in videos"
                     v-bind:event="event"
                     v-bind:key="event.token"
                     :playlistForVideos="playlistForVideos"
@@ -148,23 +148,6 @@ export default {
         selectAll() {
             return this.videos.length == this.selectedVideos.length;
         },
-
-        videos_visible() {
-            let ret = [];
-            for (const video of this.videos) {
-                let write_perm = video.perm === 'owner' || video.perm === 'write';
-                let has_playlist_seminar = !(video.playlist_seminar == null);
-                let is_visible = video.playlist_seminar?.visibility === "visible";
-                let is_hidden = video.playlist_seminar?.visibility === "hidden";
-                let has_timestamp = video.playlist_seminar?.visible_timestamp !== null;
-                let timestamp_expired = Date.parse(video.playlist_seminar?.visible_timestamp) < Date.now();
-
-                if (write_perm || !has_playlist_seminar || is_visible || (is_hidden && has_timestamp && timestamp_expired)) {
-                    ret.push(video);
-                }
-            }
-            return ret;
-        }
     },
 
     methods: {

--- a/vueapp/components/Videos/VideosList.vue
+++ b/vueapp/components/Videos/VideosList.vue
@@ -61,7 +61,7 @@
 
             <ul class="oc--episode-list--small" v-else>
                 <VideoCard
-                    v-for="event in videos"
+                    v-for="event in videos_visible"
                     v-bind:event="event"
                     v-bind:key="event.token"
                     :playlistForVideos="playlistForVideos"
@@ -147,6 +147,23 @@ export default {
 
         selectAll() {
             return this.videos.length == this.selectedVideos.length;
+        },
+
+        videos_visible() {
+            let ret = [];
+            for (const video of this.videos) {
+                let write_perm = video.perm === 'owner' || video.perm === 'write';
+                let has_playlist_seminar = !(video.playlist_seminar == null);
+                let is_visible = video.playlist_seminar?.visibility === "visible";
+                let is_hidden = video.playlist_seminar?.visibility === "hidden";
+                let has_timestamp = video.playlist_seminar?.visible_timestamp !== null;
+                let timestamp_expired = Date.parse(video.playlist_seminar?.visible_timestamp) < Date.now();
+
+                if (write_perm || !has_playlist_seminar || is_visible || (is_hidden && has_timestamp && timestamp_expired)) {
+                    ret.push(video);
+                }
+            }
+            return ret;
         }
     },
 


### PR DESCRIPTION
When calling the database via the "PlaylistVideoList" route, videos are now filtered according to their visibility on a course-specific basis.
- Dozents and higher perms see all videos.
- Default visibility is the one of the playlist (oc_playlist_seminar).
- Custom visibility for a video in a playlist in a course (oc_playlist_seminar_video).
  - Timestamping will filter out all videos with a timestamp in the future 

Configurable for every VideoCard (With VideoEdit component)
- Setting the visibility radio button to default will set the timestamp to null
- Any change on the visibility radio buttons that make the timestamp invalid will set it to null
- Any change to the timestamp will set the radio button accordingly (if invalid)
- Remove button to set timestamp input null

UserRoles are now set correctly depending on the visibility and timestamp. For the Timestamp, permission is granted 15 minutes in advance