### PR TITLE
Fix tag selection in searchbar #696

### DIFF
--- a/lib/Models/Tags.php
+++ b/lib/Models/Tags.php
@@ -2,6 +2,8 @@
 
 namespace Opencast\Models;
 
+use Opencast\Models\Videos;
+
 class Tags extends \SimpleORMap
 {
     protected static function configure($config = [])
@@ -9,5 +11,83 @@ class Tags extends \SimpleORMap
         $config['db_table'] = 'oc_tags';
 
         parent::configure($config);
+    }
+
+    /**
+     * Get the tags from all videos the user has access too
+     * 
+     * @return array
+     *  [
+     *      tag1,
+     *      tag2,
+     *      tag3,
+     *      ...    
+     *  ];
+     */
+    public static function getUserVideosTags()
+    {
+        global $user, $perm;
+
+        $query = 'SELECT tag FROM oc_tags'.
+                ' LEFT JOIN oc_video_tags AS vt ON (vt.tag_id = id)'.
+                ' LEFT JOIN oc_video_user_perms AS vup ON (vt.video_id = vup.video_id)';
+        $params = [];
+        
+        // root can access all videos, no further checking for perms is necessary
+        if (!$perm->have_perm('root')) {
+            if ($perm->have_perm('admin', $user->id)) {
+                $query .= ' WHERE vt.video_id IN (:video_ids) ';
+                $params[':video_ids'] = Videos::getFilteredVideoIds($user->id);
+            } else {
+                $query .= ' WHERE vup.user_id = :user_id ';
+                $params[':user_id'] = $user->id;
+            }
+        }
+
+        $query .= ' GROUP BY tag';
+
+        $stmt = \DBManager::get()->prepare($query);
+        $stmt->execute($params);
+        return $stmt->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+
+    /**
+     * Get the tags from all visible videos in an specific playlist
+     * 
+     * @param string $playlist_id
+     * @param string $cid
+     *
+     * @return array
+     *  [
+     *      tag1,
+     *      tag2,
+     *      tag3,
+     *      ...    
+     *  ];
+     */
+    public static function getPlaylistVideosTags($playlist_id, $cid) {
+        global $perm;
+
+        $query = 'SELECT tag FROM oc_tags'.
+                ' LEFT JOIN oc_video_tags AS vt ON (vt.tag_id = id)'.
+                ' INNER JOIN oc_playlist_video AS opv ON (opv.video_id = vt.video_id AND opv.playlist_id = :playlist_id)';
+        $params = [':playlist_id' => $playlist_id];
+        
+        if (!(empty($cid) || $perm->have_perm('dozent'))) {
+            $query .= ' INNER JOIN oc_playlist_seminar AS ops ON (ops.seminar_id = :cid AND ops.playlist_id = opv.playlist_id)'.
+                    ' LEFT JOIN oc_playlist_seminar_video AS opsv ON (opsv.playlist_seminar_id = ops.id AND opsv.video_id = opv.video_id)'.
+                    ' WHERE (opsv.visibility IS NULL AND opsv.visible_timestamp IS NULL AND ops.visibility = "visible"'.
+                    ' OR opsv.visibility = "visible" AND opsv.visible_timestamp IS NULL'.
+                    ' OR opsv.visible_timestamp < NOW())';
+
+            $params[':cid'] = $cid;
+        }
+
+        $query .= ' GROUP BY tag';
+
+        $stmt = \DBManager::get()->prepare($query);
+        $stmt->execute($params);
+        return $stmt->fetchAll(\PDO::FETCH_COLUMN);
     }
 }

--- a/lib/RouteMap.php
+++ b/lib/RouteMap.php
@@ -95,6 +95,8 @@ class RouteMap
         $this->app->delete('/schedule/{course_id}/{termin_id}', Routes\Schedule\ScheduleDelete::class);
 
         $this->app->get('/tags', Routes\Tags\TagListForUser::class);
+        $this->app->get('/tags/videos', Routes\Tags\TagListForUserVideos::class);
+        $this->app->get('/tags/videos/playlist/{token}', Routes\Tags\TagListForPlaylistVideos::class);
 
         $this->app->get('/config/simple', Routes\Config\SimpleConfigList::class);
         $this->app->post('/log', Routes\Log\LogEntryCreate::class);

--- a/lib/Routes/Tags/TagListForPlaylistVideos.php
+++ b/lib/Routes/Tags/TagListForPlaylistVideos.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Opencast\Routes\Tags;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Opencast\Errors\AuthorizationFailedException;
+use Opencast\Errors\Error;
+use Opencast\OpencastTrait;
+use Opencast\OpencastController;
+use Opencast\Models\Playlists;
+use Opencast\Models\Tags;
+
+class TagListForPlaylistVideos extends OpencastController
+{
+    use OpencastTrait;
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        global $perm;
+
+        $params = $request->getQueryParams();
+
+        // first, check if user has access to this playlist
+        $playlist = Playlists::findOneByToken($args['token']);
+        if (!$playlist) {
+            throw new \AccessDeniedException();
+        }
+
+        // check if playlist is connected to the passed course and user is part of that course as well
+        $permission = false;
+        if ($params['cid']) {
+            if ($perm->have_studip_perm($params['cid'], 'user')) {
+                $permission = true;
+            }
+        }
+
+        if (!$params['cid'] || !$permission) {
+            // check what permissions the current user has on the playlist
+            $uperm = $playlist->getUserPerm();
+
+            if (empty($uperm) || !$uperm)
+            {
+                throw new \AccessDeniedException();
+            }
+        }
+
+        $ret = Tags::getPlaylistVideosTags($playlist->id, $params['cid']);
+
+        return $this->createResponse($ret, $response->withStatus(200));
+    }
+}

--- a/lib/Routes/Tags/TagListForUserVideos.php
+++ b/lib/Routes/Tags/TagListForUserVideos.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Opencast\Routes\Tags;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Opencast\Errors\AuthorizationFailedException;
+use Opencast\Errors\Error;
+use Opencast\OpencastTrait;
+use Opencast\OpencastController;
+use Opencast\Models\Tags;
+
+class TagListForUserVideos extends OpencastController
+{
+    use OpencastTrait;
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        $ret = Tags::getUserVideosTags();
+
+        return $this->createResponse($ret, $response->withStatus(200));
+    }
+}

--- a/vueapp/components/SearchBar.vue
+++ b/vueapp/components/SearchBar.vue
@@ -54,8 +54,8 @@
             </ul>
 
             <ul v-if="tokenState == 'value' && token.type == 'tag'">
-                <li v-for="tag in filteredTags" v-bind:key="tag.id" @click="selectToken(tag)">
-                    {{ tag.tag }}
+                <li v-for="(tag, index) in filteredTags" v-bind:key="index" @click="selectToken(tag)">
+                    {{ tag }}
                 </li>
             </ul>
 
@@ -96,7 +96,7 @@ export default {
     computed: {
         ...mapGetters([
             'videoSort',
-            'availableTags',
+            'availableVideoTags',
             'playlists',
             'playlist'
         ]),
@@ -104,10 +104,9 @@ export default {
         filteredTags() {
             let filteredTags = [];
 
-            for (let i = 0; i < this.availableTags.length; i++) {
-                 if (!this.searchTokens.find(token => token.value == this.availableTags[i].tag)
-                ) {
-                    filteredTags.push(this.availableTags[i]);
+            for (let i = 0; i < this.availableVideoTags.length; i++) {
+                if (!this.searchTokens.find(token => token.value == this.availableVideoTags[i])) {
+                    filteredTags.push(this.availableVideoTags[i]);
                 }
             }
             return filteredTags;
@@ -224,8 +223,8 @@ export default {
             } else if (this.tokenState == 'value')
             {
                 if (this.token.type == 'tag') {
-                    this.token.value      = content.tag;
-                    this.token.value_name = content.tag;
+                    this.token.value      = content;
+                    this.token.value_name = content;
                 } else if (this.token.type == 'playlist') {
                     this.token.value      = content.token;
                     this.token.value_name = content.title;
@@ -269,8 +268,6 @@ export default {
     },
 
     mounted() {
-        this.$store.dispatch('updateAvailableTags');
-
         if (this.playlist) {
             // Default sort option should already be selected
             this.inputSort = this.availableSortOrders.find(elem => elem.field == this.videoSort.field && elem.order == this.videoSort.order);

--- a/vueapp/store/videos.module.js
+++ b/vueapp/store/videos.module.js
@@ -16,6 +16,7 @@ const state = {
         lastPage: 0,
         items: 0
     },
+    availableVideoTags: [],
     playlistForVideos: null,
     videoShares: {},
     courseVideosToCopy: [],
@@ -45,6 +46,10 @@ const getters = {
 
     search(state) {
         return state.search
+    },
+
+    availableVideoTags(state) {
+        return state.availableVideoTags
     },
 
     playlistForVideos(state) {
@@ -108,6 +113,7 @@ const actions = {
             route: 'videos',
             filters: data,
         })
+        .then(() => dispatch('loadAvailableVideoTags'));
     },
 
     async loadPlaylistVideos({ commit, state, dispatch, rootState }, data)
@@ -116,6 +122,24 @@ const actions = {
             route: 'playlists/' + data.token + '/videos',
             filters: data,
         })
+        .then(() => dispatch('loadAvailableVideoTags', {token: data.token, cid: data.cid}));
+    },
+
+    async loadAvailableVideoTags({ commit, state, dispatch, rootState }, data = []) {
+        const params = new URLSearchParams();
+        let route = '/tags/videos';
+
+        if (data.token) {
+            route += '/playlist/' + data.token;
+            if (data.cid) {
+                params.append('cid',  data.cid);
+            }
+        }
+
+        return ApiService.get(route, { params })
+            .then(({ data }) => {
+                commit('setAvailableVideoTags', data);
+            });
     },
 
     async uploadSortPositions({}, data) {
@@ -236,6 +260,10 @@ const mutations = {
 
     setShowCourseCopyDialog(state, mode) {
         state.showCourseCopyDialog = mode;
+    },
+
+    setAvailableVideoTags(state, data) {
+        state.availableVideoTags = data;
     }
 }
 


### PR DESCRIPTION
#696 

- Zwei neue Routen zum abrufen von Tags für alle Videos eines Nutzers und Tags für spezifische Playlists
- Nach fetch von Videos wird diese Liste entsprechend aktualisiert (im vue-store)
- In Searchbar werden damit alle Tags der verfügbaren Videos angezeigt (Je nach Ansicht)