### PR TITLE
Automatic Release Notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+changelog:
+
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+
+  categories:
+    - title: Security Fixes
+      labels:
+        - type:security
+
+    - title: New Features
+      labels:
+        - type:feature
+
+    - title: Usability and Accessibility
+      labels:
+        - type:usability
+        - type:accessibility
+        - type:visual-clarity
+
+    - title: Bug Fixes
+      labels:
+        - type:bug
+
+    - title: Documentation
+      labels:
+        - type:documentation
+
+    - title: Other Changes
+      labels:
+        - "type:*"


### PR DESCRIPTION
This patch configures the release notes which can be automatically generated by GitHub to have a better structure based on labels assigned to pull requests.

The release notes can be generated either by clicking the „generate release notes“ button when creating a new release manually, or this can be part of a workflow which completely automates cutting a release.

The generated release notes would look like this:
- https://github.com/opencast/opencast-editor/releases/tag/2022-10-06

Automating the whole release could look like this (here is just generates draft releases which still have to be approved manually):
- https://github.com/opencast/opencast-editor/blob/main/.github/workflows/create-release.yml