### PR TITLE
Notify pull request authors about merge conflicts

### DIFF
--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -1,0 +1,21 @@
+name: Merge conflict check
+on:
+  push:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for dirty pull requests
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "status:conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+              This pull request has conflicts ☹
+              Please resolve those so we can review the pull request.
+              Thanks.


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to automatically notify pull request authors about merge conflicts by commenting at and labeling the pull request.