### PR TITLE
Enforce proper labeling of pull requests

### DIFF
--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -1,0 +1,23 @@
+# This workflow runs on any change made to a pull-request and aims to verify
+# that the correct label is present.
+
+name: Check proper lable usage
+
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      # Ensure that one of the required labels is present and none of the undesired is absent
+      # See https://github.com/jesusvasquez333/verify-pr-label-action
+      - name: Verify PR label action
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          valid-labels: 'type:accessibility, type:bug, type:dependencies, type:documentation, type:enhancement, type:feature, type:infrastructure, type:mobile, type:security, type:tests, type:usability, type:visual-clarity'
+          invalid-labels: 'status:duplicate, status:conflicts, status:wontfix, status:backlog, status:feedback-required, status:needs-testing, status:user-story'
+          pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: true


### PR DESCRIPTION
This patch adds a GitHub Actions workflow which checks that pull requests have proper labels assigned to them.

In combination with pull request #731, this ensures that pull requests are always properly listed  in the release notes.