### PR TITLE
Fix sql duplicate service_url error

### DIFF
--- a/lib/Routes/Config/ConfigAddEdit.php
+++ b/lib/Routes/Config/ConfigAddEdit.php
@@ -29,15 +29,38 @@ class ConfigAddEdit extends OpencastController
         $json = $this->getRequestData($request);
 
         $config_checked = false;
-        // check, if a config with the same data already exists:
-        if ($args['id']) {
-            $config = Config::find($args['id']);
-        } else {
-            $config = reset(Config::findBySql('service_url = ?', [$json['config']['service_url']]));
+        $dublicate_url = false;
 
-            if (!$config) {
+        // check, if a config with the same data already exists:
+        $config = reset(Config::findBySql('service_url = ?', [$json['config']['service_url']]));
+        if ($args['id']) {
+            // PUT request - edit config
+            if ($config && $config->id !== (int)$args['id']) {
+                $dublicate_url = true;
+            }
+            else {
+                $config = Config::find($args['id']);
+            }
+        }
+        else {
+            // POST request - create config
+            if ($config) {
+                $dublicate_url = true;
+            } else {
                 $config = new Config;
             }
+        }
+        // Throw error if the url is already used
+        if ($dublicate_url) {
+            return $this->createResponse([
+                'message'=> [
+                    'type' => 'error',
+                    'text' => sprintf(
+                        _('Eine Konfiguration mit der angegebenen URL ist bereits vorhanden: "%s"'),
+                        $json['config']['service_url']
+                    )
+                ],
+            ], $response);
         }
 
         $new_settings = [];

--- a/lib/Routes/Config/ConfigAddEdit.php
+++ b/lib/Routes/Config/ConfigAddEdit.php
@@ -29,14 +29,14 @@ class ConfigAddEdit extends OpencastController
         $json = $this->getRequestData($request);
 
         $config_checked = false;
-        $dublicate_url = false;
+        $duplicate_url = false;
 
         // check, if a config with the same data already exists:
         $config = reset(Config::findBySql('service_url = ?', [$json['config']['service_url']]));
         if ($args['id']) {
             // PUT request - edit config
             if ($config && $config->id !== (int)$args['id']) {
-                $dublicate_url = true;
+                $duplicate_url = true;
             }
             else {
                 $config = Config::find($args['id']);
@@ -45,13 +45,13 @@ class ConfigAddEdit extends OpencastController
         else {
             // POST request - create config
             if ($config) {
-                $dublicate_url = true;
+                $duplicate_url = true;
             } else {
                 $config = new Config;
             }
         }
         // Throw error if the url is already used
-        if ($dublicate_url) {
+        if ($duplicate_url) {
             return $this->createResponse([
                 'message'=> [
                     'type' => 'error',

--- a/migrations/074_update_config_key.php
+++ b/migrations/074_update_config_key.php
@@ -4,7 +4,7 @@ class UpdateConfigKey extends Migration
 {
     public function description()
     {
-        return 'Add event state to videos, for enabling link to cutting tool and more';
+        return 'Update oc_config key to only use the service_url';
     }
 
     public function up()

--- a/migrations/074_update_config_key.php
+++ b/migrations/074_update_config_key.php
@@ -1,0 +1,33 @@
+<?php
+
+class UpdateConfigKey extends Migration
+{
+    public function description()
+    {
+        return 'Add event state to videos, for enabling link to cutting tool and more';
+    }
+
+    public function up()
+    {
+        $db = DBManager::get();
+
+        $db->exec("ALTER TABLE `oc_config`
+            DROP INDEX service_url,
+            ADD UNIQUE KEY(service_url)
+        ");
+
+        SimpleOrMap::expireTableScheme();
+    }
+
+    public function down()
+    {
+        $db = DBManager::get();
+
+        $db->exec("ALTER TABLE `oc_config`
+            DROP INDEX service_url,
+            ADD UNIQUE KEY(service_url,service_user,service_password)
+        ");
+
+        SimpleOrMap::expireTableScheme();
+    }
+}


### PR DESCRIPTION
#718

- New migration to delete service_user and service_password from oc_config key
- Route checks if a service_url already exist and throws an error message