### PR TITLE
Fixing server card issues

### DIFF
--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -166,7 +166,6 @@ class Config extends \SimpleOrMap
             ];
 
             Endpoints::deleteBySql('config_id = ?', [$this->id]);
-            Config::deleteBySql('id = ?', [$this->id]);
         } else {
             $service_host =
                 $service_url['scheme'] .'://' .
@@ -186,7 +185,18 @@ class Config extends \SimpleOrMap
                 $services_client = new ServicesClient($this->id);
 
                 $comp = null;
-                $comp = $services_client->getRESTComponents();
+                try {
+                    $comp = $services_client->getRESTComponents();
+                }
+                catch(\Exception $e) {
+                    return [
+                        'type' => 'error',
+                        'text' => sprintf(
+                            _('%s'),
+                            $e->getMessage()
+                        )
+                    ];
+                }
             } catch (AccessDeniedException $e) {
                 Endpoints::removeEndpoint($this->id, 'services');
 

--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -146,6 +146,31 @@ class Helpers
     }
 
     /**
+     * Check and make sure, that a valid server is set.
+     * If no server is detected, -1 will be stored.
+     * 
+     * @return
+     */
+    static function validateDefaultServer() {
+        $config = new \SimpleCollection(Config::findBySql(1));
+        $config_ids = $config->pluck('id');
+
+        $value = \Config::get()->OPENCAST_DEFAULT_SERVER;
+        $valid_value = $value;
+
+        if (empty($config_ids)) {
+            $valid_value = -1;
+        }
+        elseif (in_array($value, $config_ids) === false) {
+            $valid_value = reset($config_ids);
+        }
+        if ($valid_value != $value) {
+            $value = $valid_value;
+            \Config::get()->store('OPENCAST_DEFAULT_SERVER', $valid_value);
+        }
+    }
+
+    /**
      * Check if the default course playlists exists and create if necessary
      *
      * @param string $course_id

--- a/lib/Routes/Config/ConfigDelete.php
+++ b/lib/Routes/Config/ConfigDelete.php
@@ -10,6 +10,7 @@ use Opencast\OpencastTrait;
 use Opencast\OpencastController;
 use Opencast\Models\Config;
 use Opencast\Models\Videos;
+use Opencast\Models\Helpers;
 
 class ConfigDelete extends OpencastController
 {
@@ -30,6 +31,9 @@ class ConfigDelete extends OpencastController
         if (!$config->delete()) {
             throw new Error('Could not delete config.', 500);
         }
+        
+        // Validate that a correct default server is set
+        Helpers::validateDefaultServer();
 
         return $response->withStatus(204);
     }

--- a/lib/Routes/Config/ConfigEdit.php
+++ b/lib/Routes/Config/ConfigEdit.php
@@ -28,6 +28,7 @@ class ConfigEdit extends OpencastController
         $duplicate_url = false;
 
         $config = Config::find($args['id']);
+        $config_old = $config->toArray();
 
         if (empty($config)) {
             throw new Error('Could not find config with id '. $args['id'] .'.', 500);
@@ -38,6 +39,11 @@ class ConfigEdit extends OpencastController
 
         // check configuration and load endpoints
         $message = $config->updateEndpoints($this->container);
+        // Restore configuration if it failed
+        if ($message['type'] == 'error') {
+            $config->setData($config_old);
+            $config->store();
+        }
 
         $ret_config = $config->toArray();
         $ret_config = array_merge($ret_config, $ret_config['settings']);

--- a/lib/Routes/Config/ConfigUpdate.php
+++ b/lib/Routes/Config/ConfigUpdate.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Opencast\OpencastTrait;
 use Opencast\OpencastController;
 use Opencast\Models\ScheduleHelper;
+use Opencast\Models\Helpers;
 use Opencast\Models\Config;
 use Opencast\Models\WorkflowConfig;
 
@@ -24,22 +25,14 @@ class ConfigUpdate extends OpencastController
         // load oc server configs
         $config = new \SimpleCollection(Config::findBySql(1));
 
-        $config_ids = $config->pluck('id');
-
         // Storing General Configs.
         foreach ($json['settings'] as $config) {
-            // validate values
-            if ($config['name'] == 'OPENCAST_DEFAULT_SERVER') {
-                // check, that a correct server is set
-                if (in_array($config['value'], $config_ids) === false) {
-                    $config['value'] = reset($config_ids);
-                }
-            }
-
             if (in_array($config['name'], $constants['global_config_options'])) {
                 \Config::get()->store($config['name'], $config['value']);
             }
         }
+        // Validate that a correct default server is set
+        Helpers::validateDefaultServer();
 
         // Storing Resources Configs.
         $messages = [];

--- a/vueapp/components/Config/AdminConfigs.vue
+++ b/vueapp/components/Config/AdminConfigs.vue
@@ -76,6 +76,7 @@ export default {
             }
             this.$store.dispatch('configListUpdate', params)
                 .then(({ data }) => {
+                    this.$store.dispatch('configListRead');
                     if (data.messages.length) {
                         for (let i = 0; i < data.messages.length; i++ ) {
                             this.$store.dispatch('addMessage', data.messages[i]);

--- a/vueapp/components/Config/ConfigOption.vue
+++ b/vueapp/components/Config/ConfigOption.vue
@@ -47,7 +47,7 @@
                 @change="setValue(setting.value)">
         </label>
 
-        <label v-if="setting.type == 'string' && setting.options">
+        <label v-if="(setting.type == 'string' || setting.type == 'integer') && setting.options">
             <span :class="{
                 required: setting.required
             }">
@@ -61,7 +61,7 @@
                 @option:selected="setValue(setting.value)"/>
         </label>
 
-        <label v-if="setting.type == 'integer'">
+        <label v-if="setting.type == 'integer' && !setting.options">
             <span :class="{
                 required: setting.required
             }">

--- a/vueapp/components/Config/GlobalOptions.vue
+++ b/vueapp/components/Config/GlobalOptions.vue
@@ -64,7 +64,11 @@ export default {
                     setting.options = this.downloadOptions;
                     settings.push(setting);
                 }
-
+                else if (this.config_list.settings[id].name == 'OPENCAST_DEFAULT_SERVER') {
+                    let setting = this.config_list.settings[id];
+                    setting.options = this.defaultServerOptions;
+                    settings.push(setting);
+                }
                 else if (this.config_list.settings[id].name != 'OPENCAST_TOS') {
                     settings.push(this.config_list.settings[id]);
                 }
@@ -96,6 +100,26 @@ export default {
                     description: 'Mediendownloads sind verboten - für einzelne Wiedergabelisten und Videos einschaltbar'
                 }
             ];
+        },
+
+        defaultServerOptions() {
+            let options = [];
+
+            this.config_list.server.forEach(server => {
+                options.push({
+                    value: server.id,
+                    description: '[#' + server.id + '] ' + server.service_url + ''
+                })
+            });
+
+            if (options.length === 0) {
+                options.push({
+                    value: -1,
+                    description: 'Es sind keine Server eingerichtet'
+                })
+            }
+
+            return options;
         },
 
         opencastTos() {


### PR DESCRIPTION
- Fixes #708 
  - Uses dropdown of servers to choose from instead
  - Making sure the default server is always set, calls the appropriate check in the backend to set it when:
    - a new server has been added
    - a server has been deleted
    - the global config is stored

- ServerCard did save incorrect configurations
  - Fixed it by not saving configs with errors