### PR TITLE
Show status of videos in progress

### DIFF
--- a/cronjobs/opencast_clear_recycle_bin.php
+++ b/cronjobs/opencast_clear_recycle_bin.php
@@ -22,7 +22,7 @@ class OpencastClearRecycleBin extends CronJob
     {
         echo "Deletes all videos that have been marked as trash for at least " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL . " days\n";
 
-        $videos = Videos::findBySql("trashed=true AND trashed_timestamp < NOW() - INTERVAL " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL ." DAY");
+        $videos = Videos::findBySql("trashed=true AND state!='running' AND trashed_timestamp < NOW() - INTERVAL " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL ." DAY");
         foreach ($videos as $video) {
             echo "Video #" . $video->id . " (" . $video->title . ") ";
             if ($video->removeVideo()) {

--- a/vueapp/components/Videos/Actions/VideoDeletePermanent.vue
+++ b/vueapp/components/Videos/Actions/VideoDeletePermanent.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <StudipDialog
+        <StudipDialog v-if="event.state !== 'running'"
             :title="$gettext('Aufzeichnung entfernen')"
             :confirmText="$gettext('Akzeptieren')"
             :confirmClass="'accept'"
@@ -12,6 +12,19 @@
         >
             <template v-slot:dialogContent>
                 <translate>Möchten Sie die Aufzeichnung wirklich unwiderruflich entfernen?</translate>
+            </template>
+        </StudipDialog>
+
+        <StudipDialog v-else
+            :title="$gettext('Aufzeichnung entfernen')"
+            :closeText="$gettext('Abbrechen')"
+            :closeClass="'cancel'"
+            height="215"
+            @close="decline"
+            @confirm="removeVideo"
+        >
+            <template v-slot:dialogContent>
+                <translate>Das Video wird zurzeit verarbeitet und kann deshalb nicht unwiderruflich entfernt werden. Versuchen Sie es zu einem späteren Zeitpunkt erneut.</translate>
             </template>
         </StudipDialog>
     </div>

--- a/vueapp/components/Videos/VideoCard.vue
+++ b/vueapp/components/Videos/VideoCard.vue
@@ -74,7 +74,7 @@
                 <Tag v-for="tag in event.tags" v-bind:key="tag.id" :tag="tag.tag" />
             </div>
 
-            <div v-if="!videoSortMode && menuItems.length > 0 && event.state != 'running'" class="oc--actions-container">
+            <div v-if="!videoSortMode && menuItems.length > 0" class="oc--actions-container">
                 <StudipActionMenu :items="menuItems"
                     :collapseAt="menuItems.length > 1"
                     @performAction="performAction"
@@ -263,13 +263,15 @@ export default {
 
             if (!this.event?.trashed) {
                 if (this.canEdit) {
-                    menuItems.push({
-                        id: 1,
-                        label: this.$gettext('Bearbeiten'),
-                        icon: 'edit',
-                        emit: 'performAction',
-                        emitArguments: 'VideoEdit'
-                    });
+                    if (this.event?.state !== 'running') {
+                        menuItems.push({
+                            id: 1,
+                            label: this.$gettext('Bearbeiten'),
+                            icon: 'edit',
+                            emit: 'performAction',
+                            emitArguments: 'VideoEdit'
+                        });
+                    }
 
                     /*
                     menuItems.push({
@@ -308,7 +310,7 @@ export default {
                         });
                     }
 
-                    if (this.event?.publication?.annotation_tool) {
+                    if (this.event?.publication?.annotation_tool && this.event?.state !== 'running') {
                         menuItems.push({
                             id: 6,
                             label: this.$gettext('Anmerkungen hinzufügen'),
@@ -318,14 +320,16 @@ export default {
                         });
                     }
 
-                    menuItems.push({
-                        id: 7,
-                        label: this.$gettext('Untertitel hinzufügen'),
-                        icon: 'accessibility',
-                        emit: 'performAction',
-                        emitArguments: 'CaptionUpload'
-                    });
-
+                    if (this.event?.state !== 'running') {
+                        menuItems.push({
+                            id: 7,
+                            label: this.$gettext('Untertitel hinzufügen'),
+                            icon: 'accessibility',
+                            emit: 'performAction',
+                            emitArguments: 'CaptionUpload'
+                        });
+                    }
+                    
                     menuItems.push({
                         id: 8,
                         label: this.$gettext('Zum Löschen markieren'),
@@ -334,7 +338,7 @@ export default {
                         emitArguments: 'VideoDelete'
                     });
                 }
-                if (this.downloadAllowed) {
+                if (this.downloadAllowed && this.event?.state !== 'running') {
                     menuItems.push({
                         id: 2,
                         label: this.$gettext('Medien runterladen'),

--- a/vueapp/components/Videos/VideoUpload.vue
+++ b/vueapp/components/Videos/VideoUpload.vue
@@ -411,7 +411,8 @@ export default {
                         'episode': episode_id,
                         'config_id': view.selectedServer.id,
                         'title': uploadData.title,
-                        'description': uploadData.description
+                        'description': uploadData.description,
+                        'state': 'running'
                     })
                     .then(({ data }) => {
                         this.$store.dispatch('addMessage', data.message);


### PR DESCRIPTION
#760 

- State des Videos wird sofort auf 'running' gesetzt -> damit erscheint Zahnrad Symbol
  - Aber nur, wenn über "Medien hochladen" hinzugefügt
  - Funktioniert momentan nicht für StudIO uploads
- Wird so lange angezeigt, bis der discover_videos cronjob das Video in OC entdeckt und einen VideoSync dazu erstellt - Zahnrad Symbol bleibt also so lange, bis der worker cronjob das Video vernünftig einhängt
- Ausgeblendete Action Items:
  - Bearbeiten
  - Medien runterladen
  - Untertitel hinzufügen
  - Unwiderruflich entfernen
    - Löscht auch die Daten in OC, deshalb muss man warten, bis das Video verarbeitet ist
    - Blende ich nicht aus, habe dies in der Dialogbox erklärt