### PR TITLE
Remove redundant global config option

### DIFF
--- a/lib/Providers/OpencastConstants.php
+++ b/lib/Providers/OpencastConstants.php
@@ -44,8 +44,7 @@ class OpencastConstants implements \Pimple\ServiceProviderInterface
                 'OPENCAST_RESOURCE_PROPERTY_ID',
                 'OPENCAST_SUPPORT_EMAIL',
                 'OPENCAST_API_TOKEN',
-                'OPENCAST_DEFAULT_SERVER',
-                'OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL'
+                'OPENCAST_DEFAULT_SERVER'
             ]
         ];
     }


### PR DESCRIPTION
Entfernt die doppelte Einstellung für das Ablaufdatum von gelöschten Videos. 

Fixes #803