### PR TITLE
Fix typo in config description

### DIFF
--- a/migrations/071_add_video_trash.php
+++ b/migrations/071_add_video_trash.php
@@ -74,7 +74,7 @@ class AddVideoTrash extends Migration
         $stmt->execute([
             'name'        => 'OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL',
             'section'     => 'opencast',
-            'description' => 'Nach wie vielen Tage sollen zum Löschen markierte Videos tatsächlich gelöscht werden?',
+            'description' => 'Nach wie vielen Tagen sollen zum Löschen markierte Videos tatsächlich gelöscht werden?',
             'range'       => 'global',
             'type'        => 'integer',
             'value'       => 30


### PR DESCRIPTION
Behebt den Grammatikfehler in #803. Ich war mir nicht sicher, ob die Migration geändert werden darf/sollte.