### PR TITLE
Fix missing function error in studip action menu, fixes #807

### DIFF
--- a/vueapp/components/Studip/StudipActionMenu.vue
+++ b/vueapp/components/Studip/StudipActionMenu.vue
@@ -118,7 +118,7 @@ export default {
             });
         },
         shouldCollapse () {
-            const collapseAt = this.collapseAt ?? this.getStudipConfig('ACTIONMENU_THRESHOLD');
+            const collapseAt = this.collapseAt ?? window.STUDIP.config['ACTIONMENU_THRESHOLD'];
 
             if (collapseAt === false) {
                 return false;


### PR DESCRIPTION
The mixin function `getStudipConfig` of the studip core is not exposed to the plugin. I replaced it with the direct access to the global window variable.

Fixes #807 and hopefully fixes #797
