### PR TITLE
Filter existing videos when adding videos to playlist

### DIFF
--- a/vueapp/components/Videos/VideosList.vue
+++ b/vueapp/components/Videos/VideosList.vue
@@ -336,6 +336,18 @@ export default {
                 if (this.$route.name === 'videosTrashed') {
                     this.filters.trashed = true;
                 }
+                if (this.playlistForVideos?.token) {
+
+                    if (!this.filters.filters) {
+                        this.filters.filters = []
+                    }
+                    this.filters.filters.push({
+                        'compare': '!=',
+                        'type': 'playlist',
+                        'value': this.playlistForVideos.token
+                    });
+                }
+
                 this.$store.dispatch('loadMyVideos', this.filters)
                     .then(() => { this.videos_loading = false });
             }


### PR DESCRIPTION
#789 

- Im Frontend keine Assoziation zwischen auswählbaren Videos und bereits vorhandenen Videos der Playlist
- Im backend durch Filter die Videos der Playlist aus den "auswählbaren" Videos entnehmen (Mit Paging einzige sinnvolle Lösung)
  -> Mit Mehraufwand Statusflags mitgeben und Videos im Frontend ausgrauen - Ist das so bevorzugt?
  -> Erstmal so umgesetzt, dass nur die Videos angezeigt werden, die auch hinzugefügt werden können
- Fehlerhafte Zählung war nur temporär im frontend
  -> mit refresh wird counter immer korrekt gesetzt
  - Jetzt können vorhandene Videos nicht mehr hinzugefügt werden, sollte daher kein Problem mehr sein