### PR TITLE
Bulk actions as single actions

### DIFF
--- a/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
+++ b/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
@@ -1,0 +1,106 @@
+<template>
+    <div>
+        <StudipDialog
+            :title="$gettext('Verknüpfungen')"
+            :confirmText="$gettext('Speichern')"
+            :confirmClass="'accept'"
+            :closeText="$gettext('Abbrechen')"
+            :closeClass="'cancel'"
+            height="600"
+            width="600"
+            @close="decline"
+            @confirm="addToCourse"
+        >
+            <template v-slot:dialogContent>
+                <table class="default" v-if="event.playlists.length > 0">
+                    <thead>
+                        <tr>
+                            <th>
+                                {{ $gettext('Wiedergabeliste') }}
+                            </th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="(playlist, index) in event.playlists" v-bind:key="playlist.id">
+                            <td>
+                                <router-link :to="{ name: 'playlist_edit' , params: { token: playlist.token }}" target="_blank">
+                                    {{ playlist.title }}
+                                </router-link>
+                            </td>
+                            <td>
+                                <studip-icon shape="trash" role="clickable" @click="confirmDelete(index)" style="cursor: pointer"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <UserPlaylistSelectable
+                    @add="addPlaylistToList"
+                    :playlists="playlists"
+                    :selectedPlaylists="this.event.playlists"
+                />
+
+            </template>
+        </StudipDialog>
+    </div>
+</template>
+
+<script>
+import { mapGetters } from "vuex";
+import StudipDialog from '@studip/StudipDialog'
+import StudipIcon from '@studip/StudipIcon';
+
+import UserPlaylistSelectable from '@/components/UserPlaylistSelectable';
+
+export default {
+    name: 'VideoAddToSeminar',
+
+    components: {
+        StudipDialog, StudipIcon,
+        UserPlaylistSelectable
+    },
+
+    props: ['event'],
+
+    emits: ['done', 'cancel'],
+
+    computed: {
+    ...mapGetters(['playlists'])
+    },
+
+    methods: {
+        addPlaylistToList(course) {
+            this.event.playlists.push(course);
+        },
+
+        confirmDelete(playlist_index) {
+            if (confirm(this.$gettext('Sind sie sicher, dass sie dieses Video aus der Wiedergabeliste entfernen möchten?'))) {
+                this.event.playlists.splice(playlist_index, 1);
+            }
+        },
+
+        async addToCourse() {
+            let data = {
+                token: this.event.token,
+                playlists: this.event.playlists,
+            };
+            await this.$store.dispatch('addVideoToPlaylists', data)
+            .then(({ data }) => {
+                this.$store.dispatch('addMessage', data.message);
+                this.$emit('done', 'refresh');
+            }).catch(() => {
+                this.$emit('cancel');
+            });
+        },
+
+        decline() {
+            this.$emit('cancel');
+        }
+    },
+
+    mounted () {
+        this.$store.dispatch('loadPlaylists');
+    },
+}
+</script>

--- a/vueapp/components/Videos/Actions/VideoRemoveFromPlaylist.vue
+++ b/vueapp/components/Videos/Actions/VideoRemoveFromPlaylist.vue
@@ -1,17 +1,17 @@
 <template>
     <div>
         <StudipDialog
-            :title="$gettext('Video zur Wiedergabeliste hinzufügen')"
+            :title="$gettext('Video aus Wiedergabeliste entfernen')"
             :confirmText="$gettext('Akzeptieren')"
             :confirmClass="'accept'"
             :closeText="$gettext('Abbrechen')"
             :closeClass="'cancel'"
             height="200"
             @close="decline"
-            @confirm="addVideo"
+            @confirm="removeVideo"
         >
             <template v-slot:dialogContent>
-                {{ $gettext('Möchten Sie das Video wirklich zu der Wiedergabeliste hinzufügen?') }}
+                {{ $gettext('Möchten Sie das Video wirklich aus der Wiedergabeliste entfernen?') }}
             </template>
         </StudipDialog>
     </div>
@@ -22,7 +22,7 @@ import { mapGetters } from "vuex";
 import StudipDialog from '@studip/StudipDialog'
 
 export default {
-    name: 'VideoAddToPlaylist',
+    name: 'VideoRemoveFromPlaylist',
 
     components: {
         StudipDialog
@@ -33,18 +33,18 @@ export default {
     emits: ['done', 'cancel'],
 
     computed: {
-        ...mapGetters(['playlistForVideos'])
+        ...mapGetters(['playlist'])
     },
 
     methods: {
-        async addVideo() {
-            await this.$store.dispatch('addVideosToPlaylist', {
-                playlist: this.playlistForVideos.token,
+        async removeVideo() {
+            await this.$store.dispatch('removeVideosFromPlaylist', {
+                playlist: this.playlist.token,
                 videos: [this.event.token]
             }).then(() => {
                 this.$store.dispatch('addMessage', {
                     type: 'success',
-                    text: this.$gettext('Das Video wurde zu der Wiedergabeliste hinzugefügt.')
+                    text: this.$gettext('Das Video wurde aus der Wiedergabeliste entfernt.')
                 });
                 this.$emit('done', 'refresh');
             }).catch(() => {
@@ -54,7 +54,7 @@ export default {
 
         decline() {
             this.$emit('cancel');
-        }
+        },
     },
 }
 </script>

--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -288,26 +288,46 @@ export default {
                         });
                     }
 
+                    if (this.playlistMode && this.playlist) {
+                        menuItems.push({
+                            id: 2,
+                            label: this.$gettext('Aus Wiedergabeliste entfernen'),
+                            icon: 'trash',
+                            emit: 'performAction',
+                            emitArguments: 'VideoRemoveFromPlaylist'
+                        });
+                    }
+
+                    if (this.playlistForVideos) {
+                        menuItems.push({
+                            id: 3,
+                            label: this.$gettext('Zur Wiedergabeliste hinzufügen'),
+                            icon: 'add',
+                            emit: 'performAction',
+                            emitArguments: 'VideoAddToPlaylist'
+                        });
+                    }
+
                     /*
                     menuItems.push({
                         label: this.$gettext('Zu Wiedergabeliste hinzufügen'),
                         icon: 'add',
                         emit: 'performAction',
-                        emitArguments: 'VideoAddToPlaylist'
+                        emitArguments: 'VideoLinkToPlaylists'
                     });
                     */
 
                     menuItems.push({
-                        id: 3,
+                        id: 5,
                         label: this.$gettext('Verknüpfungen'),
                         icon: 'link-intern',
                         emit: 'performAction',
-                        emitArguments: 'VideoAddToPlaylist'
+                        emitArguments: 'VideoLinkToPlaylists'
                     });
 
                     if (this.event?.perm === 'owner') {
                         menuItems.push({
-                            id: 4,
+                            id: 6,
                             label: this.$gettext('Video freigeben'),
                             icon: 'share',
                             emit: 'performAction',
@@ -317,7 +337,7 @@ export default {
 
                     if (this.event?.preview?.has_previews || this.event?.state == 'cutting') {
                         menuItems.push({
-                            id: 5,
+                            id: 7,
                             label: this.$gettext('Schnitteditor öffnen'),
                             icon: 'video2',
                             emit: 'redirectAction',
@@ -327,7 +347,7 @@ export default {
 
                     if (this.event?.publication?.annotation_tool && this.event?.state !== 'running') {
                         menuItems.push({
-                            id: 6,
+                            id: 8,
                             label: this.$gettext('Anmerkungen hinzufügen'),
                             icon: 'chat',
                             emit: 'redirectAction',
@@ -337,7 +357,7 @@ export default {
 
                     if (this.event?.state !== 'running') {
                         menuItems.push({
-                            id: 7,
+                            id: 9,
                             label: this.$gettext('Untertitel hinzufügen'),
                             icon: 'accessibility',
                             emit: 'performAction',
@@ -346,7 +366,7 @@ export default {
                     }
 
                     menuItems.push({
-                        id: 8,
+                        id: 10,
                         label: this.$gettext('Zum Löschen markieren'),
                         icon: 'trash',
                         emit: 'performAction',
@@ -355,7 +375,7 @@ export default {
                 }
                 if (this.downloadAllowed && this.event?.state !== 'running') {
                     menuItems.push({
-                        id: 2,
+                        id: 4,
                         label: this.$gettext('Medien runterladen'),
                         icon: 'download',
                         emit: 'performAction',
@@ -373,7 +393,7 @@ export default {
                         emitArguments: 'VideoRestore'
                     });
                     menuItems.push({
-                        id: 8,
+                        id: 10,
                         label: this.$gettext('Unwiderruflich entfernen'),
                         icon: 'trash',
                         emit: 'performAction',
@@ -383,7 +403,7 @@ export default {
             }
 
             menuItems.push({
-                id: 7,
+                id: 9,
                 label: this.$gettext('Technisches Feedback'),
                 icon: 'support',
                 emit: 'performAction',

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -101,7 +101,7 @@
                             </StudipButton>
 
                             <StudipButton v-if="playlistEdit" icon="trash" @click.prevent="removeVideosFromPlaylist" :disabled="!hasCheckedVideos">
-                                {{ $gettext('Verknüpfungen aufheben') }}
+                                {{ $gettext('Aus Wiedergabeliste entfernen') }}
                             </StudipButton>
                         </span>
 

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -154,6 +154,7 @@ import EmptyVideoRow from './EmptyVideoRow.vue';
 import PaginationButtons from '@/components/PaginationButtons.vue';
 import MessageBox from '@/components/MessageBox.vue';
 import SearchBar from '@/components/SearchBar.vue';
+import VideoLinkToPlaylists from '@/components/Videos/Actions/VideoLinkToPlaylists.vue';
 import VideoAddToPlaylist from '@/components/Videos/Actions/VideoAddToPlaylist.vue';
 import VideoAddToSeminar from '@/components/Videos/Actions/VideoAddToSeminar.vue';
 import VideoAccess from '@/components/Videos/Actions/VideoAccess.vue';
@@ -163,6 +164,7 @@ import VideoDownload from '@/components/Videos/Actions/VideoDownload.vue';
 import VideoReport from '@/components/Videos/Actions/VideoReport.vue';
 import VideoEdit from '@/components/Videos/Actions/VideoEdit.vue';
 import VideoRestore from '@/components/Videos/Actions/VideoRestore.vue';
+import VideoRemoveFromPlaylist from '@/components/Videos/Actions/VideoRemoveFromPlaylist.vue';
 import CaptionUpload from '@/components/Videos/Actions/CaptionUpload.vue';
 import Tag from '@/components/Tag.vue'
 
@@ -175,12 +177,13 @@ export default {
         VideoRow,               EmptyVideoRow,
         PaginationButtons,      MessageBox,
         SearchBar,              Tag,
-        StudipButton,           VideoAddToPlaylist,
+        StudipButton,           VideoLinkToPlaylists,
         VideoAccess,            StudipIcon,
         VideoDownload,          VideoReport,
         VideoEdit,              VideoRestore,
         VideoDelete,            VideoDeletePermanent,
-        VideoAddToSeminar,      CaptionUpload,
+        VideoAddToSeminar,      VideoRemoveFromPlaylist,
+        VideoAddToPlaylist,     CaptionUpload,
         draggable,
     },
 


### PR DESCRIPTION
Wie in https://github.com/elan-ev/studip-opencast-plugin/issues/795#issuecomment-1752759327 beschrieben, werden die Bulk-Aktionen als Einzelaktionen rechts im Dreipunktemenü angeboten. 

Problematisch könnte sein, dass jetzt im Aktionenmenü zweimal das "trash"-Icon vorkommt. Das Icon wird für die Aktionen "Aus Wiedergabeliste entfernen" und "Zum Löschen markieren" verwendet. 
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/44410838/921da81a-b39b-460c-9fb7-40a2c46cd24d)


Außerdem könnte das Menü mittlerweile zu voll sein?

Closes #795