### PR TITLE
Prevent overflow of videos table on small devices

### DIFF
--- a/assets/css/opencast.scss
+++ b/assets/css/opencast.scss
@@ -424,6 +424,7 @@ $action-menu-icon-size: 20px;
 
             img.oc--previewimage {
                 max-height: 60px;
+                min-width: 90px;
             }
 
             .oc--duration{
@@ -449,10 +450,8 @@ $action-menu-icon-size: 20px;
                 display: flex;
                 gap: 5px;
 
-                font-size: 1.4em;
                 margin: 0;
-                overflow: hidden;
-                text-overflow: ellipsis;
+                overflow-wrap: anywhere;
             }
 
             a {


### PR DESCRIPTION
Bei dem Versuch, die Videos auf eine Zeile mit `Overflow: hidden` anzuzeigen, gab es da einige Probleme.

Damit `Overflow: hidden` funktioniert, musste das Tabellenlayout auf [fixed](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout?retiredLocale=de#fixed) gesetzt werden, damit die Overflows überhaupt versteckt werden. Das wiederum führte dazu, dass bei der Verwendung von Colspan an den Stellen der ausgeblendeten Spalten leere Spalten angezeigt wurden. 

Aus diesen Gründen und der Einheitlichkeit zu den vorhandenen Stud.IP-Tabelle wurde die folgende Lösung implementiert:
- Die Titelgröße hat die Standardgröße, wie im Dateibereich
- Das Vorschaubild hat einen Minimalbreite von 90 Pixeln, damit das Bild nicht zu sehr gestaucht wird
- Lange Titel werden bei Overflow an beliebigen Stellen gebrochen 

@ssrahn 

Ref #753 