### PR TITLE
Clear errors when success message is displayed

### DIFF
--- a/vueapp/store/messages.module.js
+++ b/vueapp/store/messages.module.js
@@ -20,6 +20,11 @@ export const actions = {
             return false;
         }
 
+        // Remove error messages if success message is displayed
+        if (message.type === "success") {
+            context.dispatch('errorClear');
+        }
+
         let messages = state.messages;
         let current_message = messages.find(msg => msg.type == message.type && msg.text == message.text);
         if (!current_message) {


### PR DESCRIPTION
Änderung:
- Vorhandene Error-Benachrichtigungen werden entfernt, wenn eine Success-Benachrichtigung hinzugefügt wird

Bei dieser Änderung war ich mir nicht ganz sicher, ob wir dieses Verhalten wirklich haben wollen. Hier stellt sich die Frage, ob Fehler- und Erfolgsnachrichten gleichzeitig auftreten können?

Closes #705