### PR TITLE
Error handling on ServerCards

### DIFF
--- a/assets/css/opencast.scss
+++ b/assets/css/opencast.scss
@@ -718,6 +718,11 @@ h2.oc--loadingbar, .oc--loadingbar-title {
             text-align: right;
             margin-right: 10px;
         }
+
+        .oc--admin--server-icons {
+            float: left;
+            margin-top: 8px;
+        }
     }
 
     .oc--admin--server-data {

--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -263,8 +263,6 @@ class Config extends \SimpleOrMap
                         'type' => 'success',
                         'text' => implode('<br>', $success_message)
                     ];
-
-                    $config_checked = true;
                 }
             } else {
                 $message = [

--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -189,13 +189,24 @@ class Config extends \SimpleOrMap
                     $comp = $services_client->getRESTComponents();
                 }
                 catch(\Exception $e) {
-                    return [
-                        'type' => 'error',
-                        'text' => sprintf(
-                            _('%s'),
-                            $e->getMessage()
-                        )
-                    ];
+                    if (str_starts_with($e->getMessage(), 'cURL error 6')) {
+                        return [
+                            'type' => 'error',
+                            'text' => sprintf(
+                                _('Die angegebene URL %s konnte nicht gefunden werden. Überprüfen Sie bitte ihre Eingabe und versuchen Sie es erneut.'),
+                                $service_host
+                            )
+                        ];
+                    }
+                    else {
+                        return [
+                            'type' => 'error',
+                            'text' => sprintf(
+                                _('%s'),
+                                $e->getMessage()
+                            )
+                        ];
+                    }
                 }
             } catch (AccessDeniedException $e) {
                 Endpoints::removeEndpoint($this->id, 'services');
@@ -203,7 +214,7 @@ class Config extends \SimpleOrMap
                 $message = [
                     'type' => 'error',
                     'text' => sprintf(
-                        _('Fehlerhafte Zugangsdaten für die Opencast Installation mit der URL "%s". Überprüfen Sie bitte die eingebenen Daten.'),
+                        _('Fehlerhafte Zugangsdaten für die Opencast Installation mit der URL "%s". Überprüfen Sie bitte die eingegebenen Daten.'),
                         $service_host
                     )
                 ];

--- a/lib/Routes/Config/ConfigAdd.php
+++ b/lib/Routes/Config/ConfigAdd.php
@@ -25,7 +25,6 @@ class ConfigAdd extends OpencastController
 
         $json = $this->getRequestData($request);
 
-        $config_checked = false;
         $duplicate_url = false;
 
         // check, if a config with the same data already exists:
@@ -68,7 +67,7 @@ class ConfigAdd extends OpencastController
         $ret_config = array_merge($ret_config, $ret_config['settings']);
         unset($ret_config['settings']);
 
-        if ($config_checked) {
+        if ($message['type'] == 'success') {
             $lti = LtiHelper::getLaunchData($config->id);
 
             return $this->createResponse([

--- a/lib/Routes/Config/ConfigEdit.php
+++ b/lib/Routes/Config/ConfigEdit.php
@@ -24,7 +24,6 @@ class ConfigEdit extends OpencastController
 
         $json = $this->getRequestData($request);
 
-        $config_checked = false;
         $duplicate_url = false;
 
         $config = Config::find($args['id']);
@@ -49,7 +48,7 @@ class ConfigEdit extends OpencastController
         $ret_config = array_merge($ret_config, $ret_config['settings']);
         unset($ret_config['settings']);
 
-        if ($config_checked) {
+        if ($message['type'] == 'success') {
             $lti = LtiHelper::getLaunchData($config->id);
 
             return $this->createResponse([

--- a/vueapp/components/Config/EditServer.vue
+++ b/vueapp/components/Config/EditServer.vue
@@ -212,43 +212,63 @@ export default {
         },
 
         checkConfigResponse(data) {
-            if (data.lti !== undefined) {
-                this.checkLti(data.lti);
-            }
             if (data.message !== undefined) {
-                this.$store.dispatch('addMessage', {
-                     type: data.message.type,
-                     text: data.message.text
-                });
+                if (data.message.type === 'error') {
+                    this.$store.dispatch('addMessage', {
+                        type: data.message.type,
+                        text: data.message.text
+                    });
+                    return;
+                }
+                else if (data.message.type === 'success') {
+                    let lti_checked = false;
+                    this.checkLti(data.lti).then((result) => {
+                        lti_checked = result;
+                    });
 
-                if(data.message.type == 'success'){
-                    this.$emit('close');
+                    this.$store.dispatch('addMessage', {
+                        type: data.message.type,
+                        text: data.message.text
+                    });
+
+                    if (!lti_checked) {
+                        this.postLtiCheckFailedMessage();
+                    }
+                    else {
+                        this.$emit('close');
+                    }
+                    return;
                 }
             }
+
+            this.$store.dispatch('addMessage', {
+                    type: 'error',
+                    text: this.$gettext('Bei der Konfiguration ist ein Fehler aufgetreten. Versuchen Sie es bitte erneut.')
+            });
         },
 
         async checkLti(data)
         {
-            let view = this;
-
             await this.$store.dispatch('authenticateLti');
 
             // make an lti call to make sure it worked, there are some caveats though...
             // - already succesful calls will not be revoked
             // - unsuccesful calls will persist even if it worked now
-            axios({
-                url: data[0].launch_url,
-                method: "GET",
-                withCredentials: true,
-            }).then(({ data }) => {
-                if (data.user_id == undefined) {
-                    view.postLtiCheckFailedMessage();
+            try {
+                const response = await axios({
+                    url: data[0].launch_url,
+                    method: "GET",
+                    withCredentials: true,
+                });
+
+                if (response.user_id == undefined) {
+                    return false;
                 } else {
-                    view.postLtiCheckSucceededMessage();
+                    return true;
                 }
-            }).catch(function (error) {
-                view.postLtiCheckFailedMessage();
-            });
+            } catch (error) {
+                return false;
+            }
         },
 
         postLtiCheckFailedMessage()
@@ -261,14 +281,6 @@ export default {
                     + 'Denken sie auch daran, in Opencast die korrekten access-control-allow-* '
                     + 'Header zu setzen.'
                 )
-            });
-        },
-
-        postLtiCheckSucceededMessage()
-        {
-            this.$store.dispatch('addMessage', {
-                type: 'success',
-                text: this.$gettext('Die LTI-Konfiguration wurde erfolgreich überprüft!')
             });
         },
 

--- a/vueapp/components/Config/ServerCard.vue
+++ b/vueapp/components/Config/ServerCard.vue
@@ -2,10 +2,13 @@
     <div class="oc--admin--server-card">
         <div class="oc--admin--server-image">
             <OpencastIcon />
-            <span v-if="config" class="oc--admin--server-id">
+            <span v-if="!isAddCard" class="oc--admin--server-id">
                 #{{ config.id }}
             </span>
-            <span v-else class="oc--admin--server-id">
+            <span v-if="!isAddCard && checkFailed" class="oc--admin--server-icons">
+                <studip-icon shape="exclaim-circle" role="status-red" :size="32"/>
+            </span>
+            <span v-if="isAddCard" class="oc--admin--server-id">
                 +
             </span>
         </div>
@@ -27,13 +30,16 @@
         <EditServer v-if="isShow"
             :id="config ? config.id : 'new'"
             :config="config"
-            @close="isShow = false"
+            @close="closeEditServer"
         />
     </div>
 </template>
 
 <script>
+import { mapGetters } from "vuex";
+
 import OpencastIcon from "@/components/OpencastIcon";
+import StudipIcon from '@studip/StudipIcon.vue';
 import EditServer from "@/components/Config/EditServer";
 
 export default {
@@ -52,18 +58,69 @@ export default {
 
     data() {
         return {
-            isShow: false
+            isShow: false,
+            checkFailed: false,
+            error_msg: this.$gettext('Überprüfung der LTI Verbindung fehlgeschlagen! '
+                + 'Kontrollieren Sie die eingetragenen Daten und stellen Sie sicher, '
+                + 'dass Cross-Origin Aufrufe von dieser Domain aus möglich sind! '
+                + 'Denken sie auch daran, in Opencast die korrekten access-control-allow-* '
+                + 'Header zu setzen.'
+            )
         }
     },
 
     components: {
         OpencastIcon,
         EditServer,
+        StudipIcon
+    },
+
+    computed: {
+        ...mapGetters([
+            'isLTIAuthenticated',
+            'errors'
+        ])
     },
 
     methods: {
         showEditServer() {
-            this.isShow = true
+            this.isShow = true;
+
+            if (!this.errors.find((e) => e === this.error_msg)) {
+                this.$store.dispatch('errorCommit', this.error_msg);
+            }
+        },
+
+        closeEditServer() {
+            this.$store.dispatch('errorRemove', this.error_msg);
+            this.isShow = false;
+        },
+
+        checkLTIPeriodically() {
+            let view = this;
+
+            // periodically check, if lti is authenticated
+            view.interval = setInterval(async () => {
+                await view.$store.dispatch('checkLTIAuthentication', {id: view.config.id, name: view.config.service_url});
+                // Make sure error is removed when authenticated
+                if (view.isLTIAuthenticated[view.config.id]) {
+                    view.$store.dispatch('errorRemove', this.error_msg);
+                    clearInterval(view.interval);
+                } else {
+                    view.checkFailed = true;
+                }
+
+                view.interval_counter++;
+                if (view.interval_counter > 10) {
+                    clearInterval(view.interval);
+                }
+            }, 2000);
+        }
+    },
+
+    mounted() {
+        if (!this.isAddCard) {
+            this.checkLTIPeriodically();
         }
     }
 }

--- a/vueapp/components/Config/WorkflowOptions.vue
+++ b/vueapp/components/Config/WorkflowOptions.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="oc--admin--section">
-        <fieldset class="collapsable">
+        <fieldset class="collapsable" v-if="!disabled">
             <legend>
                 {{ $gettext('Standardworkflows') }}
             </legend>
@@ -34,8 +34,12 @@ export default {
         I18NText
     },
 
+    props: {
+        disabled: true
+    },
+
     computed: {
-        ...mapGetters(['config', 'simple_config_list']),
+        ...mapGetters(['simple_config_list']),
 
         workflow_definitions() {
             let wf_defs = [];

--- a/vueapp/store/error.module.js
+++ b/vueapp/store/error.module.js
@@ -13,6 +13,10 @@ const actions = {
         context.commit('errorsAdd', error);
     },
 
+    errorRemove(context, error) {
+        context.commit('errorsRemove', error);
+    },
+
     errorClear(context) {
         context.commit('errorsClear');
     }
@@ -21,6 +25,13 @@ const actions = {
 const mutations = {
     errorsAdd(state, data) {
         state.errors.push(data);
+    },
+
+    errorsRemove(state, data) {
+        let idx = state.errors.indexOf(data);
+        if (idx !== -1) {
+            state.errors.splice(idx, 1);
+        }
     },
 
     errorsClear(state) {

--- a/vueapp/store/opencast.module.js
+++ b/vueapp/store/opencast.module.js
@@ -133,18 +133,20 @@ const actions = {
         return ApiService.put('courses/' + data.cid + '/upload/' + data.upload);
     },
 
-    checkLTIAuthentication({ commit }, server)
+    async checkLTIAuthentication({ commit }, server)
     {
-        axios({
-            method: 'GET',
-            url: server.name + "/lti/info.json",
-            crossDomain: true,
-            withCredentials: true,
-            headers: {
-                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
-            }
-        }).then((response) => {
-            if (response.status == 200) {
+        try {
+            const response = await axios({
+                method: 'GET',
+                url: server.name + "/lti/info.json",
+                crossDomain: true,
+                withCredentials: true,
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+                }
+            });
+    
+            if (response.status === 200) {
                 commit('setLTIStatus', {
                     server: server.id,
                     authenticated: true
@@ -155,7 +157,12 @@ const actions = {
                     authenticated: false
                 });
             }
-        });
+        } catch (error) {
+            commit('setLTIStatus', {
+                server: server.id,
+                authenticated: false
+            });
+        }
     }
 }
 


### PR DESCRIPTION
#710

- Nutzerkennung/Passwort wird korrekt behandelt
- Eintragen von duplizierten URLs nicht möglich
- URLs die nicht erreichbar sind schmeißen cURL error
  -> zB: cURL error 6: Could not resolve host: staging-oc-admin.uni-osnabrueck.d (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://staging-oc-admin.uni-osnabrueck.d/services/services.json
  - Message wurde abgegriffen und angepasst
- LTI
  - LTI kann während der Konfiguration ohne weiteres nicht behandelt werden
    -> Fehlerhafte Eingaben möglich
  - LTI wird nun nach der Konfiguration geprüft
    - Bei Fehlschlag schließt sich Dialog nicht und zeigt Meldung an
  - Bei Aufruf der Admin Seite werden alle Server periodisch überprüft (wie in der VideoTable)
    - Bei Fehler wird rotes Ausrufezeichen in der Card angezeigt
    - Bei klick auf die Card wird eine entsprechende Meldung angezeigt
- Workflows
  - Einstellungen der default Workflows erst nach Abschließung des Server-Dialogs möglich
    - Dialog wird nach "Speichern" für neuen Server nicht mehr geschlossen
    - Stattdessen wird Hinweis angezeigt und zu Standardworkflows gescrollt
- Fehlerhafte Videocards visualisieren
  - Rotes ausrufezeichen Icon an VideoCard
  - Bis jetzt lti calls, sollte man da noch mehr prüfen?