### PR TITLE
Fix workflows save in server settings

### DIFF
--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -140,6 +140,7 @@ class Config extends \SimpleOrMap
             }
             unset($json['settings']['workflow_configs']);
         }
+        WorkflowConfig::createAndUpdateByConfigId($this->id, $workflows);
 
         $this->setData($json);
         return $this->store();


### PR DESCRIPTION
Das war mir aufgefallen, als ich den Workflow von "fast" zu "schedule-and-upload" umstellen wollte. 

**Hinweis**:
Bei Workflow "fast" werden in hochgeladenen Videos keine Downloads und keine Dauern angezeigt. Zumindest ist das bei mir der Fall. Eventuell könnte dieser Hinweis zukünftige Fehlersuchen erleichtern.