### PR TITLE
Warnings for Servercard and ability to disable configs

### DIFF
--- a/cronjobs/opencast_discover_videos.php
+++ b/cronjobs/opencast_discover_videos.php
@@ -34,8 +34,8 @@ class OpencastDiscoverVideos extends CronJob
             SELECT episode FROM oc_video WHERE config_id = :config_id AND available=true
             ");
 
-        // iterate over all configured oc instances
-        $configs = Config::findBySql(1);
+        // iterate over all active configured oc instances
+        $configs = Config::findBySql('active = 1');
 
 
         foreach ($configs as $config) {

--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -49,7 +49,7 @@ class Helpers
 
     static function getConfigurationstate()
     {
-        $stmt = DBManager::get()->prepare("SELECT COUNT(*) AS c FROM oc_config");
+        $stmt = DBManager::get()->prepare("SELECT COUNT(*) AS c FROM oc_config WHERE active = 1");
         $stmt->execute();
 
         if ($stmt->fetchColumn() > 0) {
@@ -152,20 +152,23 @@ class Helpers
      * @return
      */
     static function validateDefaultServer() {
-        $config = new \SimpleCollection(Config::findBySql(1));
+        // Only check active servers
+        $config = new \SimpleCollection(Config::findBySql('active = 1'));
         $config_ids = $config->pluck('id');
 
         $value = \Config::get()->OPENCAST_DEFAULT_SERVER;
         $valid_value = $value;
 
+        // Check if list is empty
         if (empty($config_ids)) {
             $valid_value = -1;
         }
-        elseif (in_array($value, $config_ids) === false) {
+        // Check if the set value is valid (id exists)
+        elseif (in_array($valid_value, $config_ids) === false) {
             $valid_value = reset($config_ids);
         }
+        // Only update value if necessary
         if ($valid_value != $value) {
-            $value = $valid_value;
             \Config::get()->store('OPENCAST_DEFAULT_SERVER', $valid_value);
         }
     }

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -332,6 +332,9 @@ class Videos extends UPMap
             }
         }
 
+        // Only show videos with active server
+        $sql .= ' INNER JOIN oc_config ON (oc_config.id = oc_video.config_id AND oc_config.active = 1)';
+
         $where .= " AND trashed = " . $filters->getTrashed();
         $where .= " AND oc_video.token IS NOT NULL";
 

--- a/lib/Routes/Config/ConfigEdit.php
+++ b/lib/Routes/Config/ConfigEdit.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Opencast\OpencastTrait;
 use Opencast\OpencastController;
 use Opencast\Errors\AuthorizationFailedException;
+use Opencast\Models\Helpers;
 use Opencast\Models\Config;
 use Opencast\Models\Endpoints;
 use Opencast\Models\SeminarEpisodes;
@@ -43,6 +44,9 @@ class ConfigEdit extends OpencastController
             $config->setData($config_old);
             $config->store();
         }
+
+        // Validate that a correct default server is set
+        Helpers::validateDefaultServer();
 
         $ret_config = $config->toArray();
         $ret_config = array_merge($ret_config, $ret_config['settings']);

--- a/lib/Routes/Config/ConfigList.php
+++ b/lib/Routes/Config/ConfigList.php
@@ -23,6 +23,10 @@ class ConfigList extends OpencastController
 
         foreach ($config as $conf) {
             $ret_config = $conf->toArray();
+            $ret_config['active'] = filter_var(
+                $ret_config['active'],
+                FILTER_VALIDATE_BOOLEAN
+            );
             $ret_config = array_merge($ret_config, $ret_config['settings']);
             unset($ret_config['settings']);
             $config_list[] = $ret_config;

--- a/lib/Routes/Config/SimpleConfigList.php
+++ b/lib/Routes/Config/SimpleConfigList.php
@@ -27,7 +27,8 @@ class SimpleConfigList extends OpencastController
     {
         global $user;
 
-        $config = Config::findBySql(1);
+        // Only show active servers
+        $config = Config::findBySql('active = 1');
 
         $config_list = [];
 

--- a/migrations/079_add_config_active.php
+++ b/migrations/079_add_config_active.php
@@ -1,0 +1,29 @@
+<?php
+
+class AddConfigActive extends Migration
+{
+    public function description()
+    {
+        return 'Add "active" property to config, so a server config can be disabled';
+    }
+
+    public function up()
+    {
+        $db = DBManager::get();
+
+        $db->exec("ALTER TABLE `oc_config`
+            ADD `active` Boolean DEFAULT TRUE
+        ");
+
+        SimpleOrMap::expireTableScheme();
+    }
+
+    public function down()
+    {
+        $db = DBManager::get();
+
+        $db->exec('ALTER TALBE `oc_config` DROP `active` ');
+
+        SimpleOrMap::expireTableScheme();
+    }
+}

--- a/vueapp/components/Config/EditServer.vue
+++ b/vueapp/components/Config/EditServer.vue
@@ -304,7 +304,7 @@ export default {
         postLtiCheckFailedMessage()
         {
             this.$store.dispatch('addMessage', {
-                type: 'error',
+                type: 'warning',
                 text: this.$gettext('Überprüfung der LTI Verbindung fehlgeschlagen! '
                     + 'Kontrollieren Sie die eingetragenen Daten und stellen Sie sicher, '
                     + 'dass Cross-Origin Aufrufe von dieser Domain aus möglich sind! '

--- a/vueapp/components/Config/GlobalOptions.vue
+++ b/vueapp/components/Config/GlobalOptions.vue
@@ -95,10 +95,12 @@ export default {
             let options = [];
 
             this.config_list.server.forEach(server => {
-                options.push({
-                    value: Number(server.id),
-                    description: '[#' + server.id + '] ' + server.service_url + ''
-                })
+                if(server.active) {
+                    options.push({
+                        value: Number(server.id),
+                        description: server.service_url + ''
+                    });
+                }
             });
 
             if (options.length === 0) {


### PR DESCRIPTION
#832 

- Nach Erstellung des Servers wird bei Fehlschlag der LTI Verbindung eine Warning statt einem Error geschmissen. (Gilt nicht für Verbindungstests bei Aufruf der Seite)
- Bei den Verbindungstests wurde "LTI" aus der message entfernt
- Das Icon für einen Fehlerhaften Verbindungstest ist jetzt ein tooltip
  - Das tooltip ist noch buggy! Es zeigt bei meinem Testsystem eine Leere Box an, sobald es Sichtbar ist - Woran liegt das???
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/41595254/2f58bdbd-6222-4756-afd3-3b106d78f22a)
- ServerCards können deaktiviert werden
  - Zeige Checkbox in oberer rechter Ecke (statt der id des Servers)
    - Ich finde die Checkbox unschön, könnte man das auch anders machen?
  - Deaktivierbarkeit führt zu:
    - Nur aktivierte Server werden in default server Eingabe angezeigt
    - Default Server wird bei (de)aktivierung geprüft und ggf neu gesetzt
    - Videos eines deaktivierten Servers werden nicht angezeigt
    - Cronjobs überspringen deaktivierten Server
    - In der simple_config_list werden nur aktive Server angezeigt
    - Bei keinen aktiven Servern wird OC Navigation nicht angezeigt
