### PR TITLE
Messages for dialogs

### DIFF
--- a/vueapp/components/Config/ServerCard.vue
+++ b/vueapp/components/Config/ServerCard.vue
@@ -21,7 +21,7 @@
             </span>
             <span class="oc--admin--server-icons">
                 <div data-tooltip class="tooltip" v-if="!isAddCard && checkFailed">
-                    <span class="tooltip-content">
+                    <span class="tooltip-content" style="display: none">
                         {{ $gettext('Verbindungstest fehlgeschlagen.') }}
                     </span>
                     <studip-icon shape="exclaim-circle" role="status-red" :size="32"/>

--- a/vueapp/components/Config/ServerCard.vue
+++ b/vueapp/components/Config/ServerCard.vue
@@ -49,7 +49,7 @@
         <EditServer v-if="isShow"
             :id="config ? config.id : 'new'"
             :config="config"
-            @close="closeEditServer"
+            @close="isShow = false;"
         />
     </div>
 </template>
@@ -81,12 +81,16 @@ export default {
             checkFailed: false,
             interval: null,
             interval_counter: 0,
-            error_msg: this.$gettext('Überprüfung der Verbindung fehlgeschlagen! '
-                + 'Kontrollieren Sie die eingetragenen Daten und stellen Sie sicher, '
-                + 'dass Cross-Origin Aufrufe von dieser Domain aus möglich sind! '
-                + 'Denken sie auch daran, in Opencast die korrekten access-control-allow-* '
-                + 'Header zu setzen.'
-            )
+            error_msg: {
+                type: 'error',
+                text: this.$gettext('Überprüfung der Verbindung fehlgeschlagen! '
+                    + 'Kontrollieren Sie die eingetragenen Daten und stellen Sie sicher, '
+                    + 'dass Cross-Origin Aufrufe von dieser Domain aus möglich sind! '
+                    + 'Denken sie auch daran, in Opencast die korrekten access-control-allow-* '
+                    + 'Header zu setzen.'
+                ),
+                dialog: true
+            }
         }
     },
 
@@ -98,8 +102,7 @@ export default {
 
     computed: {
         ...mapGetters([
-            'isLTIAuthenticated',
-            'errors',
+            'isLTIAuthenticated'
         ])
     },
 
@@ -129,14 +132,9 @@ export default {
         showEditServer() {
             this.isShow = true;
 
-            if (this.checkFailed && !this.errors.find((e) => e === this.error_msg)) {
-                this.$store.dispatch('errorCommit', this.error_msg);
+            if (this.checkFailed) {
+                this.$store.dispatch('addMessage', this.error_msg);
             }
-        },
-
-        closeEditServer() {
-            this.$store.dispatch('errorRemove', this.error_msg);
-            this.isShow = false;
         },
 
         checkLTIPeriodically() {
@@ -148,7 +146,7 @@ export default {
                 .then(() => {
                     // Make sure error is removed when authenticated
                     if (view.isLTIAuthenticated[view.config.id]) {
-                        view.$store.dispatch('errorRemove', this.error_msg);
+                        view.$store.dispatch('removeMessage', this.error_msg);
                         view.checkFailed = false;
                         clearInterval(view.interval);
                     } else {
@@ -172,8 +170,8 @@ export default {
 
     watch: {
         checkFailed: function (newVal) {
-            if (newVal && this.isShow && !this.errors.find((e) => e === this.error_msg)) {
-                this.$store.dispatch('errorCommit', this.error_msg);
+            if (newVal && this.isShow) {
+                this.$store.dispatch('addMessage', this.error_msg);
             }
         }
     }

--- a/vueapp/components/MessageList.vue
+++ b/vueapp/components/MessageList.vue
@@ -2,8 +2,8 @@
     <div :class="{
             'oc--messages-float': float
         }">
-        <template v-if="messages.length">
-            <MessageBox v-for="message in messages"
+        <template v-if="currentMessages.length">
+            <MessageBox v-for="message in currentMessages"
                 :key="message.id"
                 :type="message.type" @hide="removeMessage(message.id)">
                     {{ message.text }}
@@ -20,19 +20,43 @@ import MessageBox from '@/components/MessageBox';
 export default {
     name: 'MessageList',
 
-    props: ['float'],
+    props: {
+        float: {
+            type: Boolean,
+            default: false
+        },
+        dialog: {
+            type: Boolean,
+            default: false
+        }
+    },
 
     components: {
         MessageBox
     },
 
     computed: {
-        ...mapGetters(['messages'])
+        ...mapGetters(['messages']),
+
+        currentMessages() {
+            if (this.dialog) {
+                return this.messages.filter(m => m.dialog === true);
+            }
+            else {
+                return this.messages.filter(m => m.dialog === false || m.dialog === undefined);
+            }
+        }
     },
 
     methods: {
         removeMessage(id) {
             this.$store.commit('removeMessage', id);
+        }
+    },
+
+    unmounted() {
+        if (this.dialog) {
+            this.$store.dispatch("clearMessages", this.dialog);
         }
     }
 }

--- a/vueapp/components/Playlists/PlaylistAddToCourseDialog.vue
+++ b/vueapp/components/Playlists/PlaylistAddToCourseDialog.vue
@@ -61,7 +61,17 @@ export default {
 
     data() {
         return {
-            selectedCourses: []
+            selectedCourses: [],
+            add_course_error: {
+                type: 'error',
+                text: 'Beim Hinzufügen des Kurses ist ein Fehler aufgetreten.',
+                dialog: true
+            },
+            remove_course_error: {
+                type: 'error',
+                text: 'Beim Entfernen des Kurses ist ein Fehler aufgetreten.',
+                dialog: true
+            }
         }
     },
 
@@ -85,7 +95,7 @@ export default {
                 // find the index of the course that was just added and remove it
                 let index = this.selectedCourses.findIndex((c) => c.id === course.id);
                 this.selectedCourses.splice(index, 1);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Hinzufügen des Kurses ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', add_course_error);
             });
         },
 
@@ -104,7 +114,7 @@ export default {
                 // find the index of the course that was just added and remove it
                 let index = this.selectedCourses.findIndex((c) => c.id === course.id);
                 this.selectedCourses.splice(index, 1);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Entfernen des Kurses ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', remove_course_error);
             });
         }
     },

--- a/vueapp/components/Playlists/PlaylistAddToCourseDialog.vue
+++ b/vueapp/components/Playlists/PlaylistAddToCourseDialog.vue
@@ -64,12 +64,12 @@ export default {
             selectedCourses: [],
             add_course_error: {
                 type: 'error',
-                text: 'Beim Hinzufügen des Kurses ist ein Fehler aufgetreten.',
+                text: $gettext('Beim Hinzufügen des Kurses ist ein Fehler aufgetreten.'),
                 dialog: true
             },
             remove_course_error: {
                 type: 'error',
-                text: 'Beim Entfernen des Kurses ist ein Fehler aufgetreten.',
+                text: $gettext('Beim Entfernen des Kurses ist ein Fehler aufgetreten.'),
                 dialog: true
             }
         }

--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -75,7 +75,8 @@
                         </div>
                     </fieldset>
 
-                    <Error :float="true" />
+                    <Error :float="true"/>
+                    <MessageList :float="true" :dialog="true"/>
 
                     <MessageBox v-if="fileUploadError" type="error">
                         {{ $gettext('Sie müssen mindestens eine Datei auswählen!') }}
@@ -92,6 +93,7 @@ import { mapGetters } from 'vuex';
 import StudipDialog from '@studip/StudipDialog'
 import StudipButton from '@studip/StudipButton'
 import MessageBox from '@/components/MessageBox'
+import MessageList from '@/components/MessageList';
 import Error from "@/components/Error";
 import ProgressBar from '@/components/ProgressBar'
 import UploadService from '@/common/upload.service'
@@ -100,12 +102,13 @@ export default {
     name: 'CaptionUpload',
 
     components: {
-        StudipDialog,
-        MessageBox,
-        Error,
-        StudipButton,
-        ProgressBar,
-    },
+    StudipDialog,
+    MessageBox,
+    Error,
+    StudipButton,
+    ProgressBar,
+    MessageList
+},
 
     emits: ['done', 'cancel'],
 
@@ -240,7 +243,11 @@ export default {
                         view.$emit('done');
                     },
                     onError: (response) => {
-                        this.$store.dispatch('errorCommit', response);
+                        this.$store.dispatch('addMessage', {
+                            type: 'error',
+                            text: response,
+                            dialog: true
+                        });
                     }
                 }
             );

--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -102,13 +102,13 @@ export default {
     name: 'CaptionUpload',
 
     components: {
-    StudipDialog,
-    MessageBox,
-    Error,
-    StudipButton,
-    ProgressBar,
-    MessageList
-},
+        StudipDialog,
+        MessageBox,
+        Error,
+        StudipButton,
+        ProgressBar,
+        MessageList
+    },
 
     emits: ['done', 'cancel'],
 

--- a/vueapp/components/Videos/Actions/VideoAccess.vue
+++ b/vueapp/components/Videos/Actions/VideoAccess.vue
@@ -112,7 +112,7 @@
                         </table>
                     </fieldset>
                 </form>
-                <MessageList />
+                <MessageList :float="true" :dialog="true"/>
             </template>
         </StudipDialog>
     </div>
@@ -142,7 +142,27 @@ export default {
 
     data() {
         return {
-            shareUsers: []
+            shareUsers: [],
+            add_perm_error: {
+                type: 'error',
+                text: this.$gettext('Beim Hinzufügen der Freigabe ist ein Fehler aufgetreten.'),
+                dialog: true
+            },
+            remove_perm_error: {
+                type: 'error',
+                text: this.$gettext('Beim Entfernen der Freigabe ist ein Fehler aufgetreten.'),
+                dialog: true
+            },
+            add_link_error: {
+                type: 'error',
+                text: this.$gettext('Beim Hinzufügen des Links ist ein Fehler aufgetreten.'),
+                dialog: true
+            },
+            remove_link_error: {
+                type: 'error',
+                text: this.$gettext('Beim Löschen des Links ist ein Fehler aufgetreten.'),
+                dialog: true
+            }
         }
     },
 
@@ -163,7 +183,7 @@ export default {
                 // find the index of the user that was just added and remove it
                 let index = this.shareUsers.findIndex(u => u.user_id == user.user_id);
                 this.shareUsers.splice(index, 1);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Hinzufügen der Freigabe ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', add_perm_error);
             })
         },
 
@@ -181,7 +201,7 @@ export default {
             })
             .catch((er) => {
                 this.videoShares.perms.splice(index, 0, perm);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Entfernen der Freigabe ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', remove_perm_error);
             })
         },
 
@@ -198,7 +218,7 @@ export default {
             }).then(({ data }) => {
                 this.initVideoShares();
             }).catch((er) => {
-                this.$store.dispatch('addMessage', this.$gettext('Beim Hinzufügen des Links ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', add_link_error);
             });
         },
 
@@ -217,7 +237,7 @@ export default {
                 this.initVideoShares();
             }).catch((er) => {
                 this.videoShares.shares.splice(index, 0, link);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Löschen des Links ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', remove_link_error);
             });
         },
 
@@ -230,7 +250,8 @@ export default {
                     document.getSelection().removeAllRanges();
                     this.$store.dispatch('addMessage', {
                         type: 'success',
-                        text: this.$gettext('Der Link wurde in die Zwischenablage kopiert.')
+                        text: this.$gettext('Der Link wurde in die Zwischenablage kopiert.'),
+                        dialog: true
                     });
                 } catch(e) {
                     console.log(e);

--- a/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
+++ b/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
@@ -62,6 +62,22 @@ export default {
 
     emits: ['done', 'cancel'],
 
+    data() {
+        return {
+            add_playlist_error: {
+                type: 'error',
+                message: this.$gettext('Beim Hinzufügen der Verknüpfung ist ein Fehler aufgetreten.'),
+                dialog: true
+            },
+
+            remove_playlist_error: {
+                type: 'error',
+                message: this.$gettext('Beim Entfernen der Verknüpfung ist ein Fehler aufgetreten.'),
+                dialog: true
+            },
+        }
+    },
+
     computed: {
     ...mapGetters(['playlists'])
     },
@@ -78,7 +94,7 @@ export default {
                 // find the index of the playlist that was just added and remove it
                 let index = this.event.playlists.findIndex(p => p.token == playlist.token);
                 this.event.playlists.splice(index, 1);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Hinzufügen der Verknüpfung ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', add_playlist_error);
             });
         },
 
@@ -96,7 +112,7 @@ export default {
             .catch(() => {
                 // add the playlist back to the list
                 this.event.playlists.splice(index, 0, link);
-                this.$store.dispatch('addMessage', this.$gettext('Beim Entfernen der Verknüpfung ist ein Fehler aufgetreten.'));
+                this.$store.dispatch('addMessage', remove_playlist_error);
             });
         },
     },

--- a/vueapp/components/Videos/VideoUpload.vue
+++ b/vueapp/components/Videos/VideoUpload.vue
@@ -190,6 +190,7 @@
                 </form>
 
                 <Error :float="true"/>
+                <MessageList :float="true" :dialog="true"/>
             </template>
         </StudipDialog>
     </div>
@@ -202,6 +203,7 @@ import StudipDialog from '@studip/StudipDialog'
 import StudipButton from '@studip/StudipButton'
 import Error from "@/components/Error";
 import MessageBox from '@/components/MessageBox'
+import MessageList from '@/components/MessageList';
 import VideoFilePreview from '@/components/Videos/VideoFilePreview'
 import ProgressBar from '@/components/ProgressBar'
 
@@ -213,13 +215,14 @@ export default {
     name: 'VideoUpload',
 
     components: {
-        StudipDialog,
-        Error,
-        MessageBox,
-        StudipButton,
-        VideoFilePreview,
-        ProgressBar,
-    },
+    StudipDialog,
+    Error,
+    MessageBox,
+    StudipButton,
+    VideoFilePreview,
+    ProgressBar,
+    MessageList
+},
 
     emits: ['done', 'cancel'],
 
@@ -446,7 +449,11 @@ export default {
                     });
                 },
                 onError: (response) => {
-                    this.$store.dispatch('errorCommit', response);
+                    this.$store.dispatch('addMessage', {
+                        type: 'error',
+                        text: response,
+                        dialog: true
+                    });
                 }
             });
         },

--- a/vueapp/components/Videos/VideoUpload.vue
+++ b/vueapp/components/Videos/VideoUpload.vue
@@ -215,14 +215,14 @@ export default {
     name: 'VideoUpload',
 
     components: {
-    StudipDialog,
-    Error,
-    MessageBox,
-    StudipButton,
-    VideoFilePreview,
-    ProgressBar,
-    MessageList
-},
+        StudipDialog,
+        Error,
+        MessageBox,
+        StudipButton,
+        VideoFilePreview,
+        ProgressBar,
+        MessageList
+    },
 
     emits: ['done', 'cancel'],
 

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -603,8 +603,11 @@ export default {
 
             this.$store.dispatch('simpleConfigListRead').then(() => {
 
-                const error_msg = this.$gettext('Es ist ein Verbindungsfehler zum Opencast Server aufgetreten. Bitte wenden Sie sich bei auftretenden Problemen an den Support oder versuchen Sie es zu einem späteren Zeitpunkt erneut.');
-                const server_ids = Object.keys(view.simple_config_list['server']);
+                const error_msg = {
+                    type: 'error',
+                    text: this.$gettext('Es ist ein Verbindungsfehler zum Opencast Server aufgetreten. Bitte wenden Sie sich bei auftretenden Problemen an den Support oder versuchen Sie es zu einem späteren Zeitpunkt erneut.')
+                };
+                    const server_ids = Object.keys(view.simple_config_list['server']);
 
                 // periodically check, if lti is authenticated
                 view.interval = setInterval(async () => {
@@ -620,12 +623,10 @@ export default {
                     await Promise.all(promises);
 
                     if (server_ids.length === 0) {
-                        view.$store.dispatch('errorRemove', error_msg);
+                        view.$store.dispatch('removeMessage', error_msg);
                         clearInterval(view.interval);
                     } else {
-                        if (!view.errors.find((e) => e === error_msg)) {
-                            view.$store.dispatch('errorCommit', error_msg);
-                        }
+                        view.$store.dispatch('addMessage', error_msg);
                     }
 
                     view.interval_counter++;

--- a/vueapp/store/messages.module.js
+++ b/vueapp/store/messages.module.js
@@ -27,7 +27,7 @@ export const actions = {
         }
 
         // If a message already exists, remove it so it appears as a new one on the bottom of the list
-        let current_message = state.messages.find(msg => msg.type == message.type && msg.text == message.text);
+        let current_message = messages.find(msg => msg.type == message.type && msg.text == message.text && msg.dialog == message.dialog);
         if (current_message) {
             context.commit('removeMessage', current_message.id);
         }
@@ -36,8 +36,18 @@ export const actions = {
         context.commit('setMessage', message);
     },
 
-    clearMessages(context) {
-        context.commit('setMessages', []);
+    removeMessage(context, message) {
+        let id = state.messages.find(msg => msg.type == message.type && msg.text == message.text && msg.dialog == message.dialog).id;
+        context.commit('removeMessage', id);
+    },
+
+    clearMessages(context, is_dialog) {
+        if (is_dialog) {
+            context.commit('setMessages', state.messages.filter(m => !m.dialog));
+        }
+        else {
+            context.commit('setMessages', state.messages.filter(m => m.dialog));
+        }
     }
 };
 

--- a/vueapp/store/messages.module.js
+++ b/vueapp/store/messages.module.js
@@ -26,11 +26,17 @@ export const actions = {
             context.dispatch('errorClear');
         }
 
-        // If a message already exists, remove it so it appears as a new one on the bottom of the list
+        let messages = state.messages;
         let current_message = messages.find(msg => msg.type == message.type && msg.text == message.text && msg.dialog == message.dialog);
-        if (current_message) {
+
+        if (!current_message) {
+            context.commit('incrementMessageMaxId')
+            message.id = state.message_max_id;
+            context.commit('setMessage', message);
+        } else {
             context.commit('removeMessage', current_message.id);
         }
+
         context.commit('incrementMessageMaxId')
         message.id = state.message_max_id;
         context.commit('setMessage', message);

--- a/vueapp/store/messages.module.js
+++ b/vueapp/store/messages.module.js
@@ -36,10 +36,6 @@ export const actions = {
         } else {
             context.commit('removeMessage', current_message.id);
         }
-
-        context.commit('incrementMessageMaxId')
-        message.id = state.message_max_id;
-        context.commit('setMessage', message);
     },
 
     removeMessage(context, message) {


### PR DESCRIPTION
#833 

- Messages haben neues attribute {dialog: Boolean}
- MessageList hat neues prop {dialog: Boolean}
- Wenn dialog gesetzt, werden in MessageList nur Messages mit dialog attribute angezeigt
- Sobald eine Dialog-MessageList schließt, werden alle Dialog-Messages gelöscht
- So haben Dialoge eigene Messages und Fehlermeldungen, der Hintergrund bleibt damit sauber
- Error die im front end abgefangen werden könnten, sollten jetzt nur noch Messages vom typen 'error' schmeißen
- Die Error-Komponente ist immer noch Global! und fängt momentan nur Fehler von außerhalb ab (hier: [app.js:49](https://github.com/elan-ev/studip-opencast-plugin/blob/5050f0d8f8411897aef455404fe615bb51dacc92/vueapp/app.js#L49))