### PR TITLE
Use Studip-Icon for ServerCard checkbox and show incoming messages always as new ones

### DIFF
--- a/vueapp/components/Config/ServerCard.vue
+++ b/vueapp/components/Config/ServerCard.vue
@@ -3,11 +3,21 @@
         <div class="oc--admin--server-image">
             <OpencastIcon />
             <span v-if="!isAddCard" class="oc--admin--server-id">
-                <input
-                    type="checkbox"
-                    :checked="config.active"
-                    @click.stop="toogleServer"
-                    :title="$gettext('Server aktivieren')">
+                <studip-icon
+                    v-if="config.active"
+                    @click="toogleServer(false)"
+                    shape="checkbox-checked"
+                    role="clickable"
+                    :size="32"
+                    style="cursor: pointer"
+                />
+                <studip-icon
+                    v-else
+                    @click="toogleServer(true)"
+                    shape="checkbox-unchecked"
+                    role="clickable"
+                    :size="32"
+                    style="cursor: pointer"/>
             </span>
             <span class="oc--admin--server-icons">
                 <div data-tooltip class="tooltip" v-if="!isAddCard && checkFailed">
@@ -94,10 +104,25 @@ export default {
     },
 
     methods: {
-        toogleServer(e) {
-            this.$store.dispatch('configUpdate', {id: this.config.id, active: e.target.checked})
+        toogleServer(active) {
+            this.config.active = active;
+            this.$store.dispatch('configUpdate', {id: this.config.id, active: active})
             .then(({ data }) => {
-                this.$store.dispatch('configListRead', data.config);
+                this.$store.dispatch('configListRead', data.config)
+                .then(() => {
+                    if (this.config.active) {
+                        this.$store.dispatch("addMessage", {
+                            type: "success",
+                            text: this.$gettext("Server wurde erfolgreich aktiviert")
+                        });
+                    }
+                    else {
+                        this.$store.dispatch("addMessage", {
+                            type: "success",
+                            text: this.$gettext("Server wurde erfolgreich deaktiviert")
+                        });
+                    }
+                });
             });
         },
 

--- a/vueapp/store/messages.module.js
+++ b/vueapp/store/messages.module.js
@@ -26,13 +26,14 @@ export const actions = {
             context.dispatch('errorClear');
         }
 
-        let messages = state.messages;
-        let current_message = messages.find(msg => msg.type == message.type && msg.text == message.text);
-        if (!current_message) {
-            context.commit('incrementMessageMaxId')
-            message.id = state.message_max_id;
-            context.commit('setMessage', message);
+        // If a message already exists, remove it so it appears as a new one on the bottom of the list
+        let current_message = state.messages.find(msg => msg.type == message.type && msg.text == message.text);
+        if (current_message) {
+            context.commit('removeMessage', current_message.id);
         }
+        context.commit('incrementMessageMaxId')
+        message.id = state.message_max_id;
+        context.commit('setMessage', message);
     },
 
     clearMessages(context) {


### PR DESCRIPTION
#832 

- Nutze Studip-Icon für Checkbox in ServerCard
- Meldung, ob Server aktiviert oder deaktiviert wurde
- Änderung in Messages
  - Vorher: Wenn bereits existierende Message hinzugefügt wird, wird die Message ignoriert
    - Bedeutet die Message bleibt einfach an der selben stelle stehen. So könnte es passieren, dass der User eine Meldung nicht wahrnimmt, wenn diese erneut auftritt und noch in der MessageList vorhanden ist
  - Jetzt: Lösche die existierende Message und füge sie erneut hinzu
    - So tauchen hinzugefügte Messages immer unten in der Liste auf und sind auffälliger für den User