### PR TITLE
Instant save in VideoCopyToSeminar using studip-select

### DIFF
--- a/vueapp/components/Videos/Actions/VideoCopyToSeminar.vue
+++ b/vueapp/components/Videos/Actions/VideoCopyToSeminar.vue
@@ -44,7 +44,6 @@
                 <UserCourseSelectable
                     @add="addCourseToList"
                     :courses="user_courses_filtered"
-                    :selectedCourses="[]"
                 />
             </template>
         </StudipDialog>


### PR DESCRIPTION
#790 

- Mit 'select' und seperater search-box nicht umsetzbar, da bei einer Suche das ausgewählte Item nicht mehr ein 'onChange' triggern kann
- Habe dafür jetzt studip-select genutzt
- Die Aufteilung in Semestern ist weiterhin eingebaut (Sieht aber nicht so schön aus wie mit 'optgroup', Semester wird einfach ausgegraut und ist nicht auswählbar)
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/41595254/d52883b5-ea41-4981-92f5-eecbbd9b37cb)
- Hab auch noch die Suche nach Semestern mit integriert