### PR TITLE
Show courses in video link to playliststs dialog

### DIFF
--- a/lib/Models/PlaylistSeminars.php
+++ b/lib/Models/PlaylistSeminars.php
@@ -217,10 +217,11 @@ class PlaylistSeminars extends \SimpleORMap
                 }
 
                 $courses[] = [
-                    'id'        => $course->id,
-                    'name'      => $course->getFullname('number-name'),
-                    'semester'  => $course->getFullname('sem-duration-name'),
-                    'lecturers' => $lecturers,
+                    'id'                    => $course->id,
+                    'name'                  => $course->getFullname('number-name'),
+                    'semester'              => $course->getFullname('sem-duration-name'),
+                    'end_semester_begin'    => $course->end_semester->beginn ?: 0,
+                    'lecturers'             => $lecturers,
                 ];
             }
         }

--- a/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
+++ b/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
@@ -52,7 +52,7 @@
 
                 <UserPlaylistSelectable
                     @add="addPlaylist"
-                    :playlists="playlists"
+                    :playlists="userPlaylists"
                     :selectedPlaylists="this.event.playlists"
                 />
 
@@ -97,7 +97,7 @@ export default {
     },
 
     computed: {
-    ...mapGetters(['playlists'])
+        ...mapGetters(['userPlaylists']),
     },
 
     methods: {
@@ -154,7 +154,9 @@ export default {
     },
 
     mounted () {
-        this.$store.dispatch('loadPlaylists');
+        this.$store.dispatch('loadUserPlaylists', {
+            limit: -1,
+        });
     },
 }
 </script>

--- a/vueapp/store/playlists.module.js
+++ b/vueapp/store/playlists.module.js
@@ -2,6 +2,7 @@ import ApiService from "@/common/api.service";
 
 const state = {
     playlists: [],
+    userPlaylists: [],
     playlist: null,
     playlistSearch: '',
     addPlaylist: false,
@@ -14,6 +15,10 @@ const state = {
 const getters = {
     playlists(state) {
         return state.playlists
+    },
+
+    userPlaylists(state) {
+        return state.userPlaylists;
     },
 
     playlist(state) {
@@ -66,6 +71,25 @@ const actions = {
         return ApiService.get($route)
             .then(({ data }) => {
                 context.commit('setPlaylists', data.playlists);
+            });
+    },
+
+    async loadUserPlaylists(context, filters) {
+        // Set filters
+        const params = new URLSearchParams();
+
+        for (let key in filters) {
+            if (key === 'filters') {
+                params.append('filters', JSON.stringify(filters.filters));
+            } else {
+                params.append(key, filters[key]);
+            }
+        }
+
+        // Get playlists user has access to
+        return ApiService.get('playlists', { params })
+            .then(({ data }) => {
+                context.commit('setUserPlaylists', data.playlists);
             });
     },
 
@@ -255,6 +279,10 @@ const mutations = {
 
     setPlaylists(state, playlists) {
         state.playlists = playlists;
+    },
+
+    setUserPlaylists(state, playlists) {
+        state.userPlaylists = playlists;
     },
 
     setPlaylist(state, playlist) {


### PR DESCRIPTION
**Important Note**:
Please merge after #893 as these changes would lead to conflicts.

Changes: 
- Show info indicator with linked courses for each playlist
- Add header with course names to playlist dropdown

Problem:
- The same playlist is listed multiple times in the dropdown if it is linked to multiple courses. This could lead to unexpected behavior in the dropdown.
- Issue #886 should solve this issue, as a playlist can then only exist in one playlist

Screenshot:
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/44410838/fca74759-b2f5-4483-9c36-d5de3002d49b)

Solve #794, #792
Fix #875

