### PR TITLE
Course default playlist enhancements

### DIFF
--- a/assets/css/opencast.scss
+++ b/assets/css/opencast.scss
@@ -1024,6 +1024,25 @@ label.oc--file-upload {
     }
 }
 
+.oc--playlist-title-contanier {
+    position: relative;
+    padding-right: 18px;
+    display: flex;
+    align-items: center;
+    .oc--playlist-title {
+        flex: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .oc--playlist-default-icon {
+        position: absolute;
+        right: 1px;
+        top: 52%;
+        transform: translateY(-50%);
+    }
+}
+
 .oc--tags {
 
     &-video {

--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -148,7 +148,7 @@ class Helpers
     /**
      * Check and make sure, that a valid server is set.
      * If no server is detected, -1 will be stored.
-     * 
+     *
      * @return
      */
     static function validateDefaultServer() {
@@ -221,5 +221,34 @@ class Helpers
         }
 
         return $playlist;
+    }
+
+    /**
+     * Check if the default course playlist exists
+     *
+     * @param string $course_id
+     *
+     * @return bool whether the default course playlist exists
+     */
+    public static function checkCourseDefaultPlaylist($course_id)
+    {
+        $default_playlist = PlaylistSeminars::findOneBySQL('seminar_id = ? AND is_default = 1', [$course_id]);
+        return !empty($default_playlist);
+    }
+
+    /**
+     * Makes sure that there is only one default playlist in a given course at a time.
+     *
+     * @param string $course_id Course id
+     * @param string $default_playlist_id default playlist id to keep
+     *
+     * @return int then number of affected rows
+     */
+    public static function ensureCourseHasOneDefaultPlaylist($course_id, $default_playlist_id)
+    {
+        $stmt = \DBManager::get()->prepare("UPDATE `oc_playlist_seminar` SET is_default = 0 WHERE seminar_id = ? AND playlist_id != ? AND is_default = 1");
+
+        $stmt->execute([$course_id, $default_playlist_id]);
+        return $stmt->rowCount();
     }
 }

--- a/lib/Routes/Course/CourseConfig.php
+++ b/lib/Routes/Course/CourseConfig.php
@@ -12,6 +12,7 @@ use Opencast\Models\SeminarSeries;
 use Opencast\Models\SeminarWorkflowConfiguration;
 use Opencast\Models\REST\SeriesClient;
 use Opencast\Providers\Perm;
+use Opencast\Models\Helpers;
 
 
 /**
@@ -61,7 +62,8 @@ class CourseConfig extends OpencastController
             'workflow'       => SeminarWorkflowConfiguration::getWorkflowForCourse($course_id),
             'edit_allowed'   => Perm::editAllowed($course_id),
             'upload_allowed' => Perm::uploadAllowed($course_id),
-            'upload_enabled' => \CourseConfig::get($course_id)->OPENCAST_ALLOW_STUDENT_UPLOAD ? 1 : 0
+            'upload_enabled' => \CourseConfig::get($course_id)->OPENCAST_ALLOW_STUDENT_UPLOAD ? 1 : 0,
+            'has_default_playlist' => Helpers::checkCourseDefaultPlaylist($course_id)
         ];
 
         return $this->createResponse($results, $response);

--- a/lib/Routes/Course/CourseListPlaylist.php
+++ b/lib/Routes/Course/CourseListPlaylist.php
@@ -34,11 +34,8 @@ class CourseListPlaylist extends OpencastController
 
         // check if user has access to this seminar
         if (!$perm->have_studip_perm($course_id, 'user')) {
-           throw new \AccessDeniedException();
+            throw new \AccessDeniedException();
         }
-
-        // check, if the default course playlist exists, if not create it
-        Helpers::checkCoursePlaylist($course_id);
 
         // find all playlists of the seminar
         $seminar_playlists = Playlists::getCoursePlaylists($course_id, new Filter($params), $user->id);
@@ -46,11 +43,6 @@ class CourseListPlaylist extends OpencastController
 
         foreach ($seminar_playlists['playlists'] as $seminar_playlist) {
             $data = $seminar_playlist->toSanitizedArray();
-
-            // if this is the default playlist for the course, change the title
-            if ($seminar_playlist->is_default == '1') {
-                $data['title'] = _('Kurswiedergabeliste');
-            }
 
             $playlist_list[] = $data;
         }

--- a/lib/Routes/Playlist/PlaylistList.php
+++ b/lib/Routes/Playlist/PlaylistList.php
@@ -32,6 +32,20 @@ class PlaylistList extends OpencastController
             $playlist['mkdate'] = ($playlist['mkdate'] == '0000-00-00 00:00:00')
             ? 0 : \strtotime($playlist['mkdate']);
             $playlist_list[$playlist->id] = $playlist->toSanitizedArray();
+
+            // Adding the tooltip text for the playlist that is default in a course.
+            $courses = $playlist->courses;
+            $course_names = [];
+            foreach ($courses as $course) {
+                $default_course_playlist = PlaylistSeminars::findOneBySQL('playlist_id = ? AND seminar_id = ? AND is_default = 1', [$playlist->id, $course->id]);
+                if (!empty($default_course_playlist)) {
+                    $course_names[] = $course->getFullname('number-name-semester');
+                }
+            }
+            if (!empty($course_names)) {
+                $tooltip_info = sprintf(_('Standard-Kurswiedergabeliste in: %s'), implode(", ", $course_names));
+                $playlist_list[$playlist->id]['default_course_tooltip'] = $tooltip_info;
+            }
         }
 
         $courses_ids = PlaylistSeminars::getUserPlaylistsCourses();

--- a/lib/Routes/Playlist/PlaylistUpdate.php
+++ b/lib/Routes/Playlist/PlaylistUpdate.php
@@ -66,15 +66,21 @@ class PlaylistUpdate extends OpencastController
         $playlist->setData($json);
         $playlist->store();
 
-        $playlist['mkdate'] = ($playlist['mkdate'] == '0000-00-00 00:00:00') 
+        $playlist['mkdate'] = ($playlist['mkdate'] == '0000-00-00 00:00:00')
             ? 0 : \strtotime($playlist['mkdate']);
 
         $ret_playlist = $playlist->toSanitizedArray();
+
+        // Add extra params to send back to frontend.
         $ret_playlist['users'] = [[
             'user_id'  => $user->id,
             'fullname' => \get_fullname($user->id),
             'perm'     => $uperm
         ]];
+
+        if (isset($json['is_default'])) {
+            $ret_playlist['is_default'] = $json['is_default'];
+        }
 
         return $this->createResponse($ret_playlist, $response->withStatus(200));
     }

--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -32,24 +32,37 @@
         </div>
         <div class="sidebar-widget-content">
             <ul class="widget-list widget-links oc--sidebar-links sidebar-navigation">
-                <li :class="{
-                    active: playlist?.token == p.token
-                    }"
-                    v-for="p in playlists"
-                    v-bind:key="p.token"
-                    v-on:click="setPlaylist(p)">
-                    <router-link :to="{ name: 'course' }">
-                        {{ p.is_default == 1 ?
-                            $gettext('Kurswiedergabeliste')
-                            : p.title
-                        }}
-                    </router-link>
-                </li>
+                <template v-if="hasDefaultPlaylist">
+                    <li :class="{
+                        active: playlist?.token == p.token
+                        }"
+                        v-for="p in playlists"
+                        v-bind:key="p.token"
+                        v-on:click="setPlaylist(p)">
+                        <router-link :to="{ name: 'course' }">
+                            <div class="oc--playlist-title-contanier">
+                                <span class="oc--playlist-title">
+                                    {{ p.title }}
+                                </span>
+                                <div v-if="p.is_default == 1"
+                                    class="tooltip oc--playlist-default-icon" :data-tooltip="$gettext('Standard-Kurswiedergabeliste')">
+                                    <studip-icon shape="check-circle" :role="playlist?.token == p.token ? 'info_alt' : 'clickable'" :size="16"/>
+                                </div>
+                            </div>
+                        </router-link>
+                    </li>
 
-                <li v-if="canEdit" @click="showCreatePlaylist">
-                    <studip-icon style="margin-top: -2px;" shape="add" role="clickable"/>
-                    {{ $gettext('Wiedergabeliste hinzufügen') }}
-                </li>
+                    <li v-if="canEdit" @click="showCreatePlaylist">
+                        <studip-icon style="margin-top: -2px;" shape="add" role="clickable"/>
+                        {{ $gettext('Wiedergabeliste hinzufügen') }}
+                    </li>
+                </template>
+                <template v-else>
+                    <li v-if="canEdit" @click="showCreateDefaultPlaylist">
+                        <studip-icon style="margin-top: -2px;" shape="add" role="clickable"/>
+                        {{ $gettext('Kurswiedergabeliste hinzufügen') }}
+                    </li>
+                </template>
             </ul>
         </div>
     </div>
@@ -73,7 +86,7 @@
         </div>
     </template>
     <template v-else>
-        <div class="sidebar-widget " id="sidebar-actions" v-if="canEdit || canUpload">
+        <div class="sidebar-widget " id="sidebar-actions" v-if="(canEdit || canUpload) && hasDefaultPlaylist">
             <div class="sidebar-widget-header">
                 {{ $gettext('Aktionen') }}
             </div>
@@ -138,6 +151,10 @@
                             <studip-icon style="margin-left: -20px;" shape="edit" role="clickable"/>
                             {{ $gettext('Wiedergabeliste bearbeiten') }}
                         </li>
+                        <li @click="showChangeDefaultPlaylist" v-if="canEdit">
+                            <studip-icon style="margin-left: -20px;" shape="refresh" role="clickable"/>
+                            {{ $gettext('Standard-Kurswiedergabeliste ändern') }}
+                        </li>
                         <li v-if="canEdit">
                             <a @click="$emit('copyAll')">
                                 <studip-icon style="margin-left: -20px;" shape="export" role="clickable"/>
@@ -150,9 +167,18 @@
         </div>
 
         <PlaylistAddCard v-if="addPlaylist"
+            :is-default="isDefault"
             @done="closePlaylistAdd"
             @cancel="closePlaylistAdd"
         />
+
+        <PlaylistsLinkCard v-if="showChangeDefaultDialog"
+            :is-default="true"
+            :custom-title="$gettext('Kurswiedergabeliste wechseln')"
+            @done="closeChangeDefaultPlaylist"
+            @cancel="closeChangeDefaultPlaylist"
+        />
+
     </template>
 </template>
 
@@ -161,12 +187,14 @@ import { mapGetters } from "vuex";
 
 import StudipIcon from '@studip/StudipIcon.vue';
 import PlaylistAddCard from '@/components/Playlists/PlaylistAddCard.vue';
-
+import PlaylistsLinkCard from '@/components/Playlists/PlaylistsLinkCard.vue';
 
 export default {
     name: 'episodes-action-widget',
     components: {
-        StudipIcon,     PlaylistAddCard
+        StudipIcon,
+        PlaylistAddCard,
+        PlaylistsLinkCard,
     },
 
     emits: ['uploadVideo', 'recordVideo', 'copyAll', 'editPlaylist', 'sortVideo', 'saveSortVideo', 'cancelSortVideo'],
@@ -174,6 +202,8 @@ export default {
     data() {
         return {
             showAddDialog: false,
+            isDefault: false,
+            showChangeDefaultDialog: false,
             semesterFilter: null,
         }
     },
@@ -190,7 +220,10 @@ export default {
 
         canSchedule() {
             try {
-                return this.cid !== undefined && this.currentUser.can_edit && this.simple_config_list['settings']['OPENCAST_ALLOW_SCHEDULER'];
+                return this.cid !== undefined &&
+                    this.currentUser.can_edit &&
+                        this.simple_config_list['settings']['OPENCAST_ALLOW_SCHEDULER'] &&
+                        this.hasDefaultPlaylist;
             } catch (error) {
                 return false;
             }
@@ -233,7 +266,7 @@ export default {
         },
 
         uploadEnabled() {
-             if (!this.course_config) {
+            if (!this.course_config) {
                 return false;
             }
 
@@ -254,7 +287,11 @@ export default {
 
         canToggleVisibility() {
             return window.OpencastPlugin.STUDIP_VERSION == '4.6' && this.canEdit;
-        }
+        },
+
+        hasDefaultPlaylist() {
+            return this.course_config?.has_default_playlist;
+        },
     },
 
     methods: {
@@ -293,7 +330,21 @@ export default {
             this.$store.dispatch('addPlaylistUI', true);
         },
 
+        showCreateDefaultPlaylist() {
+            this.isDefault = true;
+            this.$store.dispatch('addPlaylistUI', true);
+        },
+
+        showChangeDefaultPlaylist() {
+            this.showChangeDefaultDialog = true;
+        },
+
+        closeChangeDefaultPlaylist() {
+            this.showChangeDefaultDialog = false;
+        },
+
         closePlaylistAdd() {
+            this.isDefault = false;
             this.$store.dispatch('addPlaylistUI', false);
         },
 
@@ -310,7 +361,6 @@ export default {
     mounted() {
         this.$store.dispatch('simpleConfigListRead');
         this.semesterFilter = this.semester_filter;
-
     },
 
     watch: {

--- a/vueapp/components/Playlists/PlaylistAddCard.vue
+++ b/vueapp/components/Playlists/PlaylistAddCard.vue
@@ -23,11 +23,13 @@
         </StudipDialog>
 
         <PlaylistAddNewCard v-if="activeDialog === 'new'"
+            :is-default="isDefault"
             @done="done"
             @cancel="cancel"
         />
 
         <PlaylistsLinkCard v-if="activeDialog === 'link'"
+            :is-default="isDefault"
             @done="done"
             @cancel="cancel"
         />
@@ -49,6 +51,13 @@ export default {
         StudipIcon,
         PlaylistAddNewCard,
         PlaylistsLinkCard,
+    },
+
+    props: {
+        isDefault: {
+            type: Boolean,
+            default: false
+        },
     },
 
     emits: ['done', 'cancel'],

--- a/vueapp/components/Playlists/PlaylistAddNewCard.vue
+++ b/vueapp/components/Playlists/PlaylistAddNewCard.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <StudipDialog
-            :title="$gettext('Wiedergabeliste anlegen')"
+            :title="title"
             :confirmText="$gettext('Erstellen')"
             :confirmClass="'accept'"
             :closeText="$gettext('Abbrechen')"
@@ -16,10 +16,10 @@
                     <label>
                         <span class="required">Titel</span>
                         <input type="text"
-                               maxlength="255"
-                               :placeholder="$gettext('Titel der Wiedergabeliste')"
-                               v-model="playlist.title"
-                               required
+                                maxlength="255"
+                                :placeholder="$gettext('Titel der Wiedergabeliste')"
+                                v-model="playlist.title"
+                                required
                         >
                     </label>
                 </form>
@@ -40,11 +40,25 @@ export default {
         StudipDialog
     },
 
+    props: {
+        isDefault: {
+            type: Boolean,
+            default: false
+        },
+    },
+
+    computed: {
+        title() {
+            return this.isDefault ? this.$gettext('Kurswiedergabeliste anlegen') : this.$gettext('Wiedergabeliste anlegen');
+        }
+    },
+
     data() {
         return {
             playlist: {
                 title: '',
-                visibility: 'internal'
+                visibility: 'internal',
+                is_default: false
             }
         }
     },
@@ -54,6 +68,9 @@ export default {
             if (!this.$refs['playlistAddNewCard-form'].reportValidity()) {
                 return false;
             }
+
+            this.playlist.is_default = this.isDefault;
+
             this.$store.dispatch('addPlaylist', this.playlist);
             this.$emit('done');
         }

--- a/vueapp/components/Playlists/PlaylistCard.vue
+++ b/vueapp/components/Playlists/PlaylistCard.vue
@@ -7,6 +7,10 @@
         <td>
             <router-link :to="{ name: 'playlist', params: { token: playlist.token } }">
                 {{ playlist.title }}
+                <span v-if="playlist?.default_course_tooltip" class="tooltip tooltip-important" data-tooltip title="" tabindex="0"
+                >
+                    <span class="tooltip-content" v-html="playlist.default_course_tooltip"></span>
+                </span>
             </router-link>
 
             <div class="oc--tags oc--tags-playlist">

--- a/vueapp/components/Playlists/PlaylistEditCard.vue
+++ b/vueapp/components/Playlists/PlaylistEditCard.vue
@@ -12,7 +12,7 @@
         >
             <template v-slot:dialogContent>
                 <form class="default" ref="playlistEditCard-form">
-                    <label v-if="!isDefaultCoursePlaylist">
+                    <label>
                         <span class="required">Titel</span>
                         <input type="text" v-model="eplaylist.title" required>
                     </label>
@@ -67,12 +67,8 @@ export default {
 
     computed: {
         ...mapGetters([
-            'playlist', 'cid',
+            'playlist'
         ]),
-
-        isDefaultCoursePlaylist() {
-            return this.cid && this.playlist.is_default === '1';
-        },
     },
 
     methods: {

--- a/vueapp/store/messages.module.js
+++ b/vueapp/store/messages.module.js
@@ -40,8 +40,14 @@ export const actions = {
     },
 
     removeMessage(context, message) {
-        let id = state.messages.find(msg => msg.type == message.type && msg.text == message.text && msg.dialog == message.dialog).id;
-        context.commit('removeMessage', id);
+        // Prevent message runtime errors.
+        if (state?.messages && Array.isArray(state.messages)) {
+            let found = state.messages.filter(msg => msg.type == message.type && msg.text == message.text && msg.dialog == message.dialog);
+            if (found.length) {
+                let id = found[0].id;
+                context.commit('removeMessage', id);
+            }
+        }
     },
 
     clearMessages(context, is_dialog) {

--- a/vueapp/views/Course.vue
+++ b/vueapp/views/Course.vue
@@ -88,7 +88,7 @@ export default {
         }
     },
 
-      data() {
+    data() {
         return {
             uploadDialog: false,
             editPlaylistDialog: false,

--- a/vueapp/views/CoursesVideos.vue
+++ b/vueapp/views/CoursesVideos.vue
@@ -1,6 +1,9 @@
 <template>
     <div>
-        <VideosTable
+        <MessageBox type="info" v-if="!hasDefaultPlaylist">
+                {{ $gettext('Für diesen Kurs gibt es keine Standard-Kurswiedergabeliste. Versuchen Sie bitte, im Aktionsmenü eine zu erstellen.') }}
+        </MessageBox>
+        <VideosTable v-else
             :playlist="playlist"
             :cid="cid"
             :editable="canEdit"
@@ -11,12 +14,13 @@
 <script>
 import { mapGetters } from "vuex";
 import VideosTable from "@/components/Videos/VideosTable";
-
+import MessageBox from '@/components/MessageBox.vue';
 
 export default {
     name: "CourseVideos",
     components: {
-      VideosTable
+        VideosTable,
+        MessageBox
     },
 
     computed: {
@@ -24,6 +28,10 @@ export default {
 
         canEdit() {
             return this.course_config?.edit_allowed ?? false;
+        },
+
+        hasDefaultPlaylist() {
+            return this.course_config?.has_default_playlist;
         },
     },
 


### PR DESCRIPTION
This PR fixes #878,

### Description
Please refer to the linked-issue.

### Concept
Things to consider:
- A course must always have only one default playlist at a time.
- Teachers must create a new playlist, or link already existing one as default playlist when the course doesn't have one.
- There would be no more" Course playlist" or "Kurswiedergabeliste" in the sidebar, but a check icon with info.
- A Playlist can be assigned to many courses as default one.
- In Workspace Playlist table, those playlists that are default in courses will get an info icon with shows the courses.
- The course titles will get truncated (...) if they are too long.
- Teachers can change the default playlist of a course via the sidebar action item.
- The title of the default course playlist can now be changed.
- In case the default playlist is not created manually and the cronjob catches the course and recognizes that there is no default playlist, then it creates it automatically as before with the name of the course as playlist. 

### Extras:
- the `messages.find` is undefined error is also fixed in this PR

### Video
The following brief video is intended to help you with new changes.


https://github.com/elan-ev/studip-opencast-plugin/assets/53179227/c0ebcf3b-8829-45dd-a472-502beeadecf8


