### PR TITLE
Playlist copy

### DIFF
--- a/lib/Models/PlaylistSeminars.php
+++ b/lib/Models/PlaylistSeminars.php
@@ -219,6 +219,7 @@ class PlaylistSeminars extends \SimpleORMap
                 $courses[] = [
                     'id'        => $course->id,
                     'name'      => $course->getFullname('number-name'),
+                    'semester'  => $course->getFullname('sem-duration-name'),
                     'lecturers' => $lecturers,
                 ];
             }

--- a/lib/Models/Playlists.php
+++ b/lib/Models/Playlists.php
@@ -325,6 +325,15 @@ class Playlists extends UPMap
 
         $data['tags'] = $this->tags->toArray();
 
+        $data['courses'] = [];
+        if (!empty($this->courses)) {
+            $data['courses'] = PlaylistSeminars::getCoursesArray(
+                $this->courses->map(function ($course) {
+                    return $course->id;
+                })
+            );
+        }
+
         if (!is_null($data['allow_download'])) {
             $data['allow_download'] = filter_var(
                 $data['allow_download'],

--- a/lib/Models/Playlists.php
+++ b/lib/Models/Playlists.php
@@ -357,7 +357,8 @@ class Playlists extends UPMap
         foreach ($this->videos as $video) {
             PlaylistVideos::create([
                 'playlist_id' => $new_playlist->id,
-                'video_id' => $video->video_id,
+                'video_id'    => $video->video_id,
+                'order'       => $video->order,
             ]);
         }
 

--- a/lib/Models/Playlists.php
+++ b/lib/Models/Playlists.php
@@ -49,20 +49,11 @@ class Playlists extends UPMap
      */
     public static function getCoursePlaylists(String $course_id, Filter $filters, String $user_id = null)
     {
-        global $user;
-
-        if (!$user_id) {
-            $user_id = $user->id;
-        }
-
         // Check if user has access to playlist
-        $sql    = " INNER JOIN oc_playlist ON (oc_playlist.id = oc_playlist_seminar.playlist_id)"
-                 ." LEFT JOIN oc_playlist_user_perms AS ocp ON (ocp.playlist_id = oc_playlist.id)";
-        $where  = " WHERE oc_playlist_seminar.seminar_id = :course_id"
-                 ." AND (oc_playlist_seminar.is_default = 1 OR ocp.user_id = :user_id AND ocp.perm IN ('owner', 'write', 'read')) ";
+        $sql    = " INNER JOIN oc_playlist ON (oc_playlist.id = oc_playlist_seminar.playlist_id)";
+        $where  = " WHERE oc_playlist_seminar.seminar_id = :course_id ";
         $params = [
             ':course_id' => $course_id,
-            ':user_id' => $user_id,
         ];
 
         return self::getFilteredPlaylists([

--- a/lib/Models/Tags.php
+++ b/lib/Models/Tags.php
@@ -188,4 +188,28 @@ class Tags extends \SimpleORMap
         $stmt->execute($params);
         return $stmt->fetchAll(\PDO::FETCH_COLUMN);
     }
+
+    public function copy(String $playlist_id = null, Videos $video_id = null)
+    {
+        global $user;
+
+        $new_tag = Tags::create([
+            'tag' => $this->tag,
+            'user_id' => $user->id,
+        ]);
+
+        if (!empty($playlist_id)) {
+            PlaylistTags::create([
+                'playlist_id' => $playlist_id,
+                'tag_id' => $new_tag->id,
+            ]);
+        }
+
+        if (!empty($video_id)) {
+            VideoTags::create([
+                'video_id' => $video_id,
+                'tag_id' => $new_tag->id,
+            ]);
+        }
+    }
 }

--- a/lib/Models/Tags.php
+++ b/lib/Models/Tags.php
@@ -193,22 +193,26 @@ class Tags extends \SimpleORMap
     {
         global $user;
 
-        $new_tag = Tags::create([
-            'tag' => $this->tag,
-            'user_id' => $user->id,
-        ]);
+        // Copy tag only if user not own the tag
+        $tag = Tags::findOneBySQL('tag = ? AND user_id = ?', [$this->tag, $user->id]);
+        if (empty($tag)) {
+            $tag = Tags::create([
+                'tag' => $this->tag,
+                'user_id' => $user->id,
+            ]);
+        }
 
         if (!empty($playlist_id)) {
             PlaylistTags::create([
                 'playlist_id' => $playlist_id,
-                'tag_id' => $new_tag->id,
+                'tag_id' => $tag->id,
             ]);
         }
 
         if (!empty($video_id)) {
             VideoTags::create([
                 'video_id' => $video_id,
-                'tag_id' => $new_tag->id,
+                'tag_id' => $tag->id,
             ]);
         }
     }

--- a/lib/RouteMap.php
+++ b/lib/RouteMap.php
@@ -61,6 +61,7 @@ class RouteMap
         $this->app->get('/playlists/{token}', Routes\Playlist\PlaylistShow::class);
         $this->app->put('/playlists/{token}', Routes\Playlist\PlaylistUpdate::class);
         $this->app->delete('/playlists/{token}', Routes\Playlist\PlaylistDelete::class);
+        $this->app->post('/playlists/{token}/copy', Routes\Playlist\PlaylistCopy::class);
 
 
         $this->app->get('/playlists/{token}/videos', Routes\Playlist\PlaylistVideoList::class);

--- a/lib/Routes/Playlist/PlaylistCopy.php
+++ b/lib/Routes/Playlist/PlaylistCopy.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Opencast\Routes\Playlist;
+
+use Opencast\Models\Playlists;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Opencast\OpencastTrait;
+use Opencast\OpencastController;
+use Opencast\Models\PlaylistSeminars;
+
+/**
+ * Copy a playlist into a course or user contents
+ */
+class PlaylistCopy extends OpencastController
+{
+    use OpencastTrait;
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        global $perm;
+
+        $json = $this->getRequestData($request);
+
+        $source_playlist = Playlists::findOneByToken($args['token']);
+        $destination_course = $json['course'];  // TODO: Check if null is possible
+
+        // Check playlist permissions
+        $perm_playlist = $source_playlist->getUserPerm();
+        if (empty($perm_playlist) || !$perm_playlist)
+        {
+            throw new \AccessDeniedException();
+        }
+
+        // Check permission on course destination
+        if (!empty($destination_course)) {
+            if (!$perm->have_studip_perm('tutor', $destination_course)) {
+                throw new \AccessDeniedException();
+            }
+        }
+
+        try {
+            // Copy playlist
+            $new_playlist = $source_playlist->copy();
+
+            // Link new playlist to course
+            if (!empty($destination_course)) {
+                PlaylistSeminars::create([
+                    'playlist_id' => $new_playlist->id,
+                    'seminar_id'  => $destination_course,
+                    'visibility'  => 'visible' //TODO set visibility correctly
+                ]);
+            }
+
+            $message = [
+                'type' => 'success',
+                'text' => _('Die Kopiervorgänge wurden ausgeführt.')
+            ];
+        } catch (\Throwable $e) {
+
+            $message = [
+                'type' => 'error',
+                'text' => _('Die Kopiervorgänge konnten nicht abgeschlossen werden!')
+            ];
+        }
+
+        return $this->createResponse([
+            'message' => $message
+        ], $response->withStatus(200));
+    }
+}

--- a/lib/Routes/Playlist/PlaylistCopy.php
+++ b/lib/Routes/Playlist/PlaylistCopy.php
@@ -23,7 +23,7 @@ class PlaylistCopy extends OpencastController
         $json = $this->getRequestData($request);
 
         $source_playlist = Playlists::findOneByToken($args['token']);
-        $destination_course = $json['course'];  // TODO: Check if null is possible
+        $destination_course = $json['course'];
 
         // Check playlist permissions
         $perm_playlist = $source_playlist->getUserPerm();
@@ -48,7 +48,7 @@ class PlaylistCopy extends OpencastController
                 PlaylistSeminars::create([
                     'playlist_id' => $new_playlist->id,
                     'seminar_id'  => $destination_course,
-                    'visibility'  => 'visible' //TODO set visibility correctly
+                    'visibility'  => 'visible'
                 ]);
             }
 

--- a/migrations/084_duplicate_linked_playlists.php
+++ b/migrations/084_duplicate_linked_playlists.php
@@ -1,0 +1,99 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+use Opencast\Models\Playlists;
+use Opencast\Models\PlaylistSeminars;
+use Opencast\Models\PlaylistsUserPerms;
+use Opencast\Models\PlaylistTags;
+use Opencast\Models\PlaylistVideos;
+
+class DuplicateLinkedPlaylists extends Migration
+{
+    public function description()
+    {
+        return 'Duplicate playlists with more than one linked course to ensure that playlists belong to only one course';
+    }
+
+    public function up()
+    {
+        $playlists = Playlists::findBySQL('1');
+
+        foreach ($playlists as $playlist) {
+            $courses = $playlist->courses;
+
+            if (count($courses) > 1) {
+                // Duplicate playlists for n-1 courses
+                for ($i = 0; $i < count($courses) - 1; $i++) {
+                    $course = $courses[$i];
+
+                    // Copy playlist
+                    $new_playlist = $this->copyPlaylist($playlist);
+
+                    $playlist_seminar = PlaylistSeminars::findOneBySQL('playlist_id = ? AND `seminar_id` = ?', [
+                        $playlist->id,
+                        $course->id,
+                    ]);
+
+                    // Link playlist copy to course
+                    PlaylistSeminars::create([
+                        'playlist_id' => $new_playlist->id,
+                        'seminar_id'  => $course->id,
+                        'is_default'  => $playlist_seminar->is_default,
+                        'visibility'  => 'visible',
+                        'allow_download'  => $playlist_seminar->allow_download,
+                    ]);
+
+                    // Remove link to original playlist
+                    $playlist_seminar->delete();
+                }
+            }
+        }
+    }
+
+    public function copyPlaylist($playlist) {
+        // Copy playlist
+        $new_playlist = Playlists::create([
+            'title'          => $playlist->title,
+            'visibility'     => $playlist->visibility,
+            'chdate'         => $playlist->chdate,
+            'mkdate'         => $playlist->mkdate,
+            'sort_order'     => $playlist->sort_order,
+            'allow_download' => $playlist->allow_download,
+        ]);
+
+        // Copy user perms
+        foreach ($playlist->perms as $perm) {
+            PlaylistsUserPerms::create([
+                'playlist_id' => $new_playlist->id,
+                'user_id'     => $perm->user_id,
+                'perm'        => $perm->perm
+            ]);
+        }
+
+        // Link videos to new playlist
+        foreach ($playlist->videos as $video) {
+            PlaylistVideos::create([
+                'playlist_id' => $new_playlist->id,
+                'video_id'    => $video->video_id,
+                'order'       => $video->order,
+                'chdate'      => $video->chdate,
+                'mkdate'      => $video->mkdate,
+            ]);
+        }
+
+        // Copy tags
+        foreach ($playlist->tags as $tag) {
+            PlaylistTags::create([
+                'playlist_id' => $new_playlist->id,
+                'tag_id' => $tag->id,
+            ]);
+        }
+
+        $new_playlist->store();
+
+        return $new_playlist;
+    }
+
+    public function down() {}
+}

--- a/vueapp/components/Playlists/EmptyPlaylistCard.vue
+++ b/vueapp/components/Playlists/EmptyPlaylistCard.vue
@@ -5,6 +5,7 @@
         <td><span class="oc--loadingbar"></span></td>
         <td><span class="oc--loadingbar"></span></td>
         <td><span class="oc--loadingbar"></span></td>
+        <td><span class="oc--loadingbar"></span></td>
         <td></td>
     </tr>
 </template>

--- a/vueapp/components/Playlists/PlaylistAddCard.vue
+++ b/vueapp/components/Playlists/PlaylistAddCard.vue
@@ -14,9 +14,10 @@
                         <studip-icon shape="add" role="clickable" size="50"/>
                         {{ $gettext('Neu erstellen') }}
                     </a>
-                    <a href="#" @click.prevent="activeDialog = 'link'">
-                        <studip-icon shape="group" role="clickable" size="50"/>
-                        {{ $gettext('Bestehende verknüpfen') }}
+
+                    <a href="#" @click.prevent="activeDialog = 'copy'">
+                        <studip-icon shape="copy" role="clickable" size="50"/>
+                        {{ $gettext('Bestehende kopieren') }}
                     </a>
 
                     <!--
@@ -34,6 +35,11 @@
             @cancel="cancel"
         />
 
+        <PlaylistsCopyCard v-if="activeDialog === 'copy'"
+            @done="done"
+            @cancel="cancel"
+        />
+
         <PlaylistsLinkCard v-if="activeDialog === 'link'"
             @done="done"
             @cancel="cancel"
@@ -46,6 +52,7 @@
 import StudipDialog from '@studip/StudipDialog'
 import StudipIcon from "@studip/StudipIcon";
 import PlaylistAddNewCard from "@/components/Playlists/PlaylistAddNewCard";
+import PlaylistsCopyCard from "@/components/Playlists/PlaylistsCopyCard";
 import PlaylistsLinkCard from "@/components/Playlists/PlaylistsLinkCard";
 
 export default {
@@ -55,6 +62,7 @@ export default {
         StudipDialog,
         StudipIcon,
         PlaylistAddNewCard,
+        PlaylistsCopyCard,
         PlaylistsLinkCard,
     },
 

--- a/vueapp/components/Playlists/PlaylistAddCard.vue
+++ b/vueapp/components/Playlists/PlaylistAddCard.vue
@@ -18,6 +18,13 @@
                         <studip-icon shape="group" role="clickable" size="50"/>
                         {{ $gettext('Bestehende verknüpfen') }}
                     </a>
+
+                    <!--
+                    <a href="#" @click.prevent="activeDialog = 'link'">
+                        <studip-icon shape="group" role="clickable" size="50"/>
+                        {{ $gettext('Bestehende verknüpfen') }}
+                    </a>
+                    -->
                 </div>
             </template>
         </StudipDialog>

--- a/vueapp/components/Playlists/PlaylistCard.vue
+++ b/vueapp/components/Playlists/PlaylistCard.vue
@@ -14,7 +14,13 @@
             </div>
         </td>
 
-        <td></td>
+        <td>
+            {{ courseName }}
+        </td>
+
+        <td>
+            {{ semester }}
+        </td>
 
         <td>
             {{ playlist.videos_count }}
@@ -108,6 +114,24 @@ export default {
         isChecked() {
             return this.selectedPlaylists.indexOf(this.playlist.token) >= 0;
         },
+
+        course() {
+            if (!Array.isArray(this.playlist.courses) || this.playlist.courses.length === 0) {
+                return null;
+            }
+
+            // Assume a playlist has only one course
+            return this.playlist.courses[0];
+        },
+
+        courseName() {
+            return this.course?.name ?? '';
+        },
+
+        semester() {
+            // Assume a playlist has only one course
+            return this.course?.semester ?? '';
+        }
     },
 
     methods: {

--- a/vueapp/components/Playlists/PlaylistsCopyCard.vue
+++ b/vueapp/components/Playlists/PlaylistsCopyCard.vue
@@ -1,0 +1,78 @@
+<template>
+    <div>
+        <StudipDialog
+            :title="$gettext('Wiedergabelisten kopieren')"
+            :confirmText="$gettext('Kopieren')"
+            :disabled="selectedPlaylists.length === 0"
+            :closeText="$gettext('Schließen')"
+            :closeClass="'cancel'"
+            height="600"
+            width="800"
+            @close="cancel"
+            @confirm="copyPlaylistsToCourse"
+        >
+            <template v-slot:dialogContent>
+                <PlaylistsTable
+                    :selectable="true"
+                    :showActions="false"
+                    @selectedPlaylistsChange="updateSelectedPlaylists"
+                />
+            </template>
+        </StudipDialog>
+    </div>
+</template>
+
+<script>
+import { mapGetters } from "vuex";
+
+import StudipDialog from "@/components/Studip/StudipDialog.vue";
+import PlaylistsTable from "@/components/Playlists/PlaylistsTable.vue";
+
+export default {
+    name: "PlaylistsLinkCard",
+
+    components: {
+        StudipDialog,
+        PlaylistsTable,
+    },
+
+    emits: ['done', 'cancel'],
+
+    data() {
+        return {
+            playlists: [],
+            selectedPlaylists: [],
+        }
+    },
+
+    computed: {
+        ...mapGetters(['cid']),
+    },
+
+    methods: {
+        cancel() {
+            this.$emit('cancel');
+        },
+
+        updateSelectedPlaylists(selectedPlaylists) {
+            this.selectedPlaylists = selectedPlaylists;
+        },
+
+        copyPlaylistsToCourse() {
+            this.$store.dispatch('copyPlaylistsToCourse', {
+                course: this.cid,
+                playlists: this.selectedPlaylists
+            }).then(() => {
+                this.selectedPlaylists = [];
+                this.$store.dispatch('addMessage', {
+                    type: 'success',
+                    text: this.$gettext('Die Playlisten wurden in die Veranstaltung kopiert.')
+                });
+                this.$store.dispatch('loadPlaylists');
+                this.$store.dispatch('setPlaylistsReload', true);
+                this.$emit('done');
+            });
+        },
+    },
+};
+</script>

--- a/vueapp/components/Playlists/PlaylistsCopyCard.vue
+++ b/vueapp/components/Playlists/PlaylistsCopyCard.vue
@@ -29,7 +29,7 @@ import StudipDialog from "@/components/Studip/StudipDialog.vue";
 import PlaylistsTable from "@/components/Playlists/PlaylistsTable.vue";
 
 export default {
-    name: "PlaylistsLinkCard",
+    name: "PlaylistsCopyCard",
 
     components: {
         StudipDialog,

--- a/vueapp/components/Playlists/PlaylistsCopyCard.vue
+++ b/vueapp/components/Playlists/PlaylistsCopyCard.vue
@@ -7,7 +7,7 @@
             :closeText="$gettext('Schließen')"
             :closeClass="'cancel'"
             height="600"
-            width="800"
+            width="1200"
             @close="cancel"
             @confirm="copyPlaylistsToCourse"
         >

--- a/vueapp/components/Playlists/PlaylistsTable.vue
+++ b/vueapp/components/Playlists/PlaylistsTable.vue
@@ -15,10 +15,11 @@
         <table class="default">
             <colgroup>
                 <col v-if="selectable" style="width: 2%">
-                <col style="width: 50%">
-                <col style="width: 2%">
-                <col style="width: 20%">
-                <col style="width: 13%">
+                <col style="width: 40%">
+                <col style="width: 18%">
+                <col style="width: 18%">
+                <col style="width: 5%">
+                <col style="width: 15%">
                 <col v-if="showActions" style="width: 2%">
             </colgroup>
             <thead>
@@ -35,7 +36,13 @@
                     {{ $gettext('Name') }}
                 </th>
 
-                <th></th>
+                <th>
+                    {{ $gettext('Veranstaltung') }}
+                </th>
+
+                <th>
+                    {{ $gettext('Semester') }}
+                </th>
 
                 <th>
                     {{ $gettext('Videos') }}

--- a/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
+++ b/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
@@ -5,15 +5,27 @@
             :closeText="$gettext('Schließen')"
             :closeClass="'cancel'"
             height="600"
-            width="600"
+            width="800"
             @close="this.$emit('done', 'refresh')"
         >
             <template v-slot:dialogContent>
                 <table class="default" v-if="event.playlists.length > 0">
+                    <colgroup>
+                        <col>
+                        <col style="width: 25%">
+                        <col style="width: 25%">
+                        <col style="width: 3%">
+                    </colgroup>
                     <thead>
                         <tr>
                             <th>
                                 {{ $gettext('Wiedergabeliste') }}
+                            </th>
+                            <th>
+                                {{ $gettext('Veranstaltung') }}
+                            </th>
+                            <th>
+                                {{ $gettext('Semester') }}
                             </th>
                             <th></th>
                         </tr>
@@ -24,6 +36,12 @@
                                 <router-link :to="{ name: 'playlist' , params: { token: playlist.token }}" target="_blank">
                                     {{ playlist.title }}
                                 </router-link>
+                            </td>
+                            <td>
+                                {{ getCourseName(playlist) }}
+                            </td>
+                            <td>
+                                {{ getSemester(playlist) }}
                             </td>
                             <td>
                                 <studip-icon shape="trash" role="clickable" @click="removePlaylist(index)" style="cursor: pointer"/>
@@ -83,6 +101,24 @@ export default {
     },
 
     methods: {
+        getCourseName(playlist) {
+            if (!Array.isArray(playlist.courses) || playlist.courses.length === 0) {
+                return '';
+            }
+
+            // Assume a playlist has only one course
+            return playlist.courses[0].name;
+        },
+
+        getSemester(playlist) {
+            if (!Array.isArray(playlist.courses) || playlist.courses.length === 0) {
+                return '';
+            }
+
+            // Assume a playlist has only one course
+            return playlist.courses[0].semester;
+        },
+
         addPlaylist(playlist) {
             this.event.playlists.push(playlist);
 

--- a/vueapp/components/Videos/VideosSidebar.vue
+++ b/vueapp/components/Videos/VideosSidebar.vue
@@ -19,6 +19,7 @@
                         {{ $gettext('Gelöschte Videos') }}
                     </router-link>
                 </li>
+                <!--
                 <li :class="{
                     active: fragment == 'playlists' || fragment == 'playlist'
                     }">
@@ -26,6 +27,7 @@
                         {{ $gettext('Wiedergabelisten') }}
                     </router-link>
                 </li>
+                -->
             </ul>
         </div>
     </div>

--- a/vueapp/store/playlists.module.js
+++ b/vueapp/store/playlists.module.js
@@ -127,6 +127,15 @@ const actions = {
         }
     },
 
+    async copyPlaylistsToCourse(context, data) {
+        for (const playlist of data.playlists) {
+            await context.dispatch('copyPlaylist', {
+                course: data.course,
+                token: playlist,
+            });
+        }
+    },
+
     async updatePlaylistCourses(context, params) {
         return ApiService.put('playlists/' + params.token + '/courses', {courses: params.courses})
     },
@@ -182,6 +191,16 @@ const actions = {
                     dispatch('loadPlaylists');
                 }
             });
+    },
+
+    async copyPlaylist(context, params) {
+        let data = {};
+
+        if (params.course !== undefined) {
+            data.course = params.course;
+        }
+
+        return ApiService.post('playlists/' + params.token + '/copy', data);
     },
 
     async deletePlaylist(context, token) {


### PR DESCRIPTION
 Implements the concept in https://github.com/elan-ev/studip-opencast-plugin/issues/886#issuecomment-1893539768.

Changes:
- Hide linking of playlist in "Wiedergabeliste hinzufügen" dialog
- Hide playlists in contents sidebar
- Add copy action in "Wiedergabeliste hinzufügen" dialog
- "Videos/Wiedergabelisten übertragen" action: Copy instead of link playlists to other courses
- Show name and semester of first course in playlist tables and in "Verknüpfungen" video dialog. The other courses will be ignored in the playlist table.

Fixes:
- Currently, a course member only sees the default playlist or a playlist with at least read permission. This check is removed so that all playlist are visible for course members.

Migration:
- Duplicate playlists with more than one linked course to ensure that playlists belong to only one course
- Copy playlists with tags, videos and perms

Screenshots:
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/44410838/89ebcafb-adf8-4318-b524-4b3073413527)
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/44410838/ec27f066-9c4c-4b3a-adf2-4f8eb56648a8)
![image](https://github.com/elan-ev/studip-opencast-plugin/assets/44410838/c41fee4b-2f83-48e4-81e1-e3bde388bc9b)

