### PR TITLE
Remove link from upload legal info

### DIFF
--- a/migrations/084_upload_legal_info_remove_link.php
+++ b/migrations/084_upload_legal_info_remove_link.php
@@ -1,0 +1,22 @@
+<?php
+class UploadLegalInfoRemoveLink extends Migration
+{
+
+    function up()
+    {
+        $db = DBManager::get();
+
+        $stmt = $db->prepare("UPDATE config
+            SET `value` = :value, type = 'string'
+            WHERE field = 'OPENCAST_UPLOAD_INFO_TEXT_BODY'
+        ");
+
+        $stmt->execute([
+            ':value' => '{"de_DE":"<p>Laden Sie nur Medien hoch, an denen Sie das Nutzungsrecht besitzen!</p><ul><li>Nach §60 UrhG dürfen nur maximal 5-minütige Sequenzen aus urheberrechtlich geschützten Filmen oder Musikaufnahmen bereitgestellt werden, sofern diese einen geringen Umfang des Gesamtwerkes ausmachen.</li><li>Medien, bei denen Urheberrechtsverstöße vorliegen, werden ohne vorherige Ankündigung umgehend gelöscht.</li></ul>","en_GB":"<p>Upload</p>"}'
+        ]);
+    }
+
+    function down()
+    {
+    }
+}


### PR DESCRIPTION
Removes the paragraph link in the upload legal info by updating the config `OPENCAST_UPLOAD_INFO_TEXT_BODY` in a migration. This overwrites manually changed info texts.

Deletion of link requested in https://github.com/elan-ev/studip-opencast-plugin/issues/799#issuecomment-1849887016.

Closes #799 