### PR TITLE
Display no ghost video rows

### DIFF
--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -68,7 +68,7 @@
                 </tr>
             </thead>
 
-            <tbody v-if="Object.keys(videos_list).length === 0 && (axios_running || videos_loading)" class="oc--episode-table--empty">
+            <tbody v-if="Object.keys(videos_list).length === 0 && videos_loading" class="oc--episode-table--empty">
                 <EmptyVideoRow :showCheckbox="showCheckbox" :numberOfColumns="numberOfColumns" />
                 <EmptyVideoRow :showCheckbox="showCheckbox" :numberOfColumns="numberOfColumns" />
                 <EmptyVideoRow :showCheckbox="showCheckbox" :numberOfColumns="numberOfColumns" />


### PR DESCRIPTION
Show no loading animation during axios requests, e.g. during uploads.

Close #707
