### PR TITLE
Show warning with the effects of editing a video

### DIFF
--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -1,6 +1,15 @@
 <template>
     <div>
+        <VideoChangeWarning
+            v-if="!showCaptionsDialog"
+            :event="event"
+            :title="$gettext('Auswirkung der Bearbeitung von Untertiteln')"
+            @done="showCaptionsDialog = true"
+            @cancel="decline"
+        />
+
         <StudipDialog
+            v-if="showCaptionsDialog"
             :title="$gettext('Untertitel hinzufügen')"
             :confirmText="$gettext('Hochladen')"
             :confirmClass="uploadButtonClasses"
@@ -95,6 +104,7 @@ import MessageBox from '@/components/MessageBox'
 import MessageList from '@/components/MessageList';
 import ProgressBar from '@/components/ProgressBar'
 import UploadService from '@/common/upload.service'
+import VideoChangeWarning from '@/components/Videos/VideoChangeWarning';
 
 export default {
     name: 'CaptionUpload',
@@ -104,7 +114,8 @@ export default {
         MessageBox,
         StudipButton,
         ProgressBar,
-        MessageList
+        MessageList,
+        VideoChangeWarning
     },
 
     emits: ['done', 'cancel'],
@@ -113,7 +124,7 @@ export default {
 
     data () {
         return {
-            showAddEpisodeDialog: false,
+            showCaptionsDialog: false,
             selectedServer: false,
             fileUploadError: false,
             files: {},

--- a/vueapp/components/Videos/Actions/VideoCut.vue
+++ b/vueapp/components/Videos/Actions/VideoCut.vue
@@ -1,0 +1,40 @@
+<template>
+    <div>
+        <VideoChangeWarning
+            :event="event"
+            :title="$gettext('Auswirkung des Schnitts im Editor')"
+            @done="openEditor"
+            @cancel="decline"
+        />
+    </div>
+</template>
+
+<script>
+import StudipDialog from '@studip/StudipDialog';
+import VideoChangeWarning from '@/components/Videos/VideoChangeWarning';
+
+export default {
+    name: 'VideoCut',
+
+    components: {
+        StudipDialog,
+        VideoChangeWarning
+    },
+
+    props: ['event'],
+
+    emits: ['done', 'cancel'],
+
+    methods: {
+        openEditor() {
+            let redirectUrl = window.OpencastPlugin.REDIRECT_URL + '/editor/' + this.event.token;
+            window.open(redirectUrl, '_blank');
+            this.$emit('done');
+        },
+
+        decline() {
+            this.$emit('cancel');
+        },
+    },
+}
+</script>

--- a/vueapp/components/Videos/Actions/VideoDelete.vue
+++ b/vueapp/components/Videos/Actions/VideoDelete.vue
@@ -6,16 +6,33 @@
             :confirmClass="'accept'"
             :closeText="$gettext('Abbrechen')"
             :closeClass="'cancel'"
-            height="275"
+            :height="dialogHeight"
+            width="600"
             @close="decline"
             @confirm="removeVideo"
         >
             <template v-slot:dialogContent>
-                <translate>
-                    Möchten Sie die Aufzeichnung wirklich zum Löschen markieren?<br/><br/>
-                    Die Aufzeichnung wird damit in den "Gelöschte Videos" Bereich Ihres Arbeitsplatzes verschoben und wird nach {{simple_config_list.settings.OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL}} Tagen automatisch gelöscht.
-                    Bis zu diesem Zeitpunkt können Sie die Aufzeichnung wiederherstellen.
-                </translate>
+                <p>
+                    <translate>
+                        Möchten Sie die Aufzeichnung wirklich zum Löschen markieren?
+                    </translate>
+                </p>
+                <p>
+                    <translate>
+                        Die Aufzeichnung wird damit in den "Gelöschte Videos" Bereich Ihres Arbeitsplatzes verschoben und wird nach {{simple_config_list.settings.OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL}} Tagen automatisch gelöscht.
+                        Bis zu diesem Zeitpunkt können Sie die Aufzeichnung wiederherstellen.
+                    </translate>
+                </p>
+
+                <span v-if="event.playlists.length > 0">
+                    <p>
+                        {{ $gettext('Beim Löschen wird die Aufzeichnung aus den folgenden Wiedergabelisten entfernt.') }}
+                    </p>
+                    <VideoPlaylists
+                        :event="event"
+                        :removable="false"
+                    />
+                </span>
             </template>
         </StudipDialog>
     </div>
@@ -25,12 +42,14 @@
 import { mapGetters } from "vuex";
 
 import StudipDialog from '@studip/StudipDialog'
+import VideoPlaylists from "@/components/Videos/VideoPlaylists";
 
 export default {
     name: 'VideoDelete',
 
     components: {
-        StudipDialog
+        StudipDialog,
+        VideoPlaylists
     },
 
     props: ['event'],
@@ -41,6 +60,10 @@ export default {
         ...mapGetters([
             'simple_config_list'
         ]),
+
+        dialogHeight() {
+            return this.event.playlists.length > 0 ? 400 : 275;
+        },
     },
 
     methods: {

--- a/vueapp/components/Videos/Actions/VideoEdit.vue
+++ b/vueapp/components/Videos/Actions/VideoEdit.vue
@@ -1,6 +1,15 @@
 <template>
     <div>
+        <VideoChangeWarning
+            v-if="!showEditDialog"
+            :event="event"
+            :title="$gettext('Auswirkung der Bearbeitung')"
+            @done="showEditDialog = true"
+            @cancel="decline"
+        />
+
         <StudipDialog
+            v-if="showEditDialog"
             :title="$gettext('Video bearbeiten')"
             :closeText="$gettext('Abbrechen')"
             :confirmText="$gettext('Speichern')"
@@ -112,17 +121,20 @@ import { mapGetters } from "vuex";
 import StudipDialog from '@studip/StudipDialog';
 import StudipIcon from '@/components/Studip/StudipIcon'
 import TagBar from '@/components/TagBar.vue';
+import VideoChangeWarning from '@/components/Videos/VideoChangeWarning';
+
 
 export default {
     name: "VideoEdit",
 
     components: {
         StudipDialog, TagBar,
-        StudipIcon
+        StudipIcon,   VideoChangeWarning
     },
 
     data() {
         return {
+            showEditDialog: false,
             visibility: null,
             visible_timestamp: null,
             use_timestamp: false

--- a/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
+++ b/vueapp/components/Videos/Actions/VideoLinkToPlaylists.vue
@@ -9,53 +9,16 @@
             @close="this.$emit('done', 'refresh')"
         >
             <template v-slot:dialogContent>
-                <table class="default" v-if="event.playlists.length > 0">
-                    <colgroup>
-                        <col>
-                        <col style="width: 25%">
-                        <col style="width: 25%">
-                        <col style="width: 3%">
-                    </colgroup>
-                    <thead>
-                        <tr>
-                            <th>
-                                {{ $gettext('Wiedergabeliste') }}
-                            </th>
-                            <th>
-                                {{ $gettext('Veranstaltung') }}
-                            </th>
-                            <th>
-                                {{ $gettext('Semester') }}
-                            </th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="(playlist, index) in event.playlists" v-bind:key="playlist.id">
-                            <td>
-                                <router-link :to="{ name: 'playlist' , params: { token: playlist.token }}" target="_blank">
-                                    {{ playlist.title }}
-                                </router-link>
-                            </td>
-                            <td>
-                                {{ getCourseName(playlist) }}
-                            </td>
-                            <td>
-                                {{ getSemester(playlist) }}
-                            </td>
-                            <td>
-                                <studip-icon shape="trash" role="clickable" @click="removePlaylist(index)" style="cursor: pointer"/>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <VideoPlaylists
+                    :event="event"
+                    @removePlaylist="removePlaylist"
+                />
 
                 <UserPlaylistSelectable
                     @add="addPlaylist"
                     :playlists="playlists"
                     :selectedPlaylists="this.event.playlists"
                 />
-
             </template>
         </StudipDialog>
     </div>
@@ -64,16 +27,17 @@
 <script>
 import { mapGetters } from "vuex";
 import StudipDialog from '@studip/StudipDialog'
-import StudipIcon from '@studip/StudipIcon';
 
 import UserPlaylistSelectable from '@/components/UserPlaylistSelectable';
+import VideoPlaylists from "@/components/Videos/VideoPlaylists";
 
 export default {
     name: 'VideoLinkToPlaylists',
 
     components: {
-        StudipDialog, StudipIcon,
-        UserPlaylistSelectable
+        StudipDialog,
+        UserPlaylistSelectable,
+        VideoPlaylists
     },
 
     props: ['event'],
@@ -101,24 +65,6 @@ export default {
     },
 
     methods: {
-        getCourseName(playlist) {
-            if (!Array.isArray(playlist.courses) || playlist.courses.length === 0) {
-                return '';
-            }
-
-            // Assume a playlist has only one course
-            return playlist.courses[0].name;
-        },
-
-        getSemester(playlist) {
-            if (!Array.isArray(playlist.courses) || playlist.courses.length === 0) {
-                return '';
-            }
-
-            // Assume a playlist has only one course
-            return playlist.courses[0].semester;
-        },
-
         addPlaylist(playlist) {
             this.event.playlists.push(playlist);
 
@@ -130,7 +76,7 @@ export default {
                 // find the index of the playlist that was just added and remove it
                 let index = this.event.playlists.findIndex(p => p.token == playlist.token);
                 this.event.playlists.splice(index, 1);
-                this.$store.dispatch('addMessage', add_playlist_error);
+                this.$store.dispatch('addMessage', this.add_playlist_error);
             });
         },
 
@@ -148,7 +94,7 @@ export default {
             .catch(() => {
                 // add the playlist back to the list
                 this.event.playlists.splice(index, 0, link);
-                this.$store.dispatch('addMessage', remove_playlist_error);
+                this.$store.dispatch('addMessage', this.remove_playlist_error);
             });
         },
     },

--- a/vueapp/components/Videos/Actions/VideoRestore.vue
+++ b/vueapp/components/Videos/Actions/VideoRestore.vue
@@ -6,12 +6,25 @@
             :confirmClass="'accept'"
             :closeText="$gettext('Abbrechen')"
             :closeClass="'cancel'"
-            height="175"
+            :height="dialogHeight"
+            width="500"
             @close="decline"
             @confirm="restoreVideo"
         >
             <template v-slot:dialogContent>
-                <translate>Möchten Sie die Aufzeichnung wirklich wiederherstellen?</translate>
+                <p>
+                    {{ $gettext('Möchten Sie die Aufzeichnung wirklich wiederherstellen?') }}
+                </p>
+
+                <span v-if="event.playlists.length > 0">
+                    <p>
+                        {{ $gettext('Nach der Wiederherstellung erscheint die Aufzeichnung in den folgenden Wiedergabelisten.') }}
+                    </p>
+                    <VideoPlaylists
+                        :event="event"
+                        :removable="false"
+                    />
+                </span>
             </template>
         </StudipDialog>
     </div>
@@ -19,17 +32,25 @@
 
 <script>
 import StudipDialog from '@studip/StudipDialog'
+import VideoPlaylists from "@/components/Videos/VideoPlaylists";
 
 export default {
     name: 'VideoRestore',
 
     components: {
-        StudipDialog
+        StudipDialog,
+        VideoPlaylists
     },
 
     props: ['event'],
 
     emits: ['done', 'cancel'],
+
+    computed: {
+        dialogHeight() {
+            return this.event.playlists.length > 0 ? 350 : 200;
+        },
+    },
 
     methods: {
         async restoreVideo() {

--- a/vueapp/components/Videos/VideoChangeWarning.vue
+++ b/vueapp/components/Videos/VideoChangeWarning.vue
@@ -1,0 +1,129 @@
+<template>
+    <div>
+        <StudipDialog v-if="showWarning"
+            :title="dialogTitle"
+            :confirmText="dialogConfirmText"
+            :confirmClass="'accept'"
+            :closeText="dialogCloseText"
+            :closeClass="'cancel'"
+            height="400"
+            width="500"
+            @close="decline"
+            @confirm="accept"
+        >
+            <template v-slot:dialogContent>
+                <p>
+                    {{ dialogWarning }}
+                </p>
+
+                <VideoPlaylists
+                    :event="event"
+                    :removable="false"
+                />
+            </template>
+        </StudipDialog>
+    </div>
+</template>
+
+<script>
+import StudipDialog from '@studip/StudipDialog'
+import VideoPlaylists from "@/components/Videos/VideoPlaylists";
+import { mapGetters } from "vuex";
+
+export default {
+    name: 'VideoChangeWarning',
+
+    components: {
+        StudipDialog,
+        VideoPlaylists
+    },
+
+    props: {
+        'event': Object,
+        'title': String,
+        'warning': String,
+        'confirmText': String,
+        'closeText': String,
+        'showLinkedPlaylists': {
+            type: Boolean,
+            default: true
+        }
+    },
+
+    emits: ['done', 'cancel'],
+
+    computed: {
+        ...mapGetters(['playlist']),
+
+        dialogTitle() {
+            if (this.title) {
+                return this.title;
+            }
+
+            return this.$gettext('Auswirkungen der Videoänderungen');
+        },
+
+        dialogWarning() {
+            if (this.warning) {
+                return this.warning;
+            }
+
+            return this.$gettext('Wenn Sie dieses Video verändern, wirken sich diese Änderungen auf die folgenden ' +
+                'Wiedergabelisten aus, zu denen das Video hinzugefügt wurde. Sollten Sie dies nicht beabsichtigen, ' +
+                'laden Sie das Video erneut hoch und bearbeiten Sie diese Kopie.');
+        },
+
+        dialogConfirmText() {
+            if (this.confirmText) {
+                return this.confirmText;
+            }
+
+            return this.$gettext('Trotzdem bearbeiten');
+        },
+
+        dialogCloseText() {
+            if (this.closeText) {
+                return this.closeText;
+            }
+
+            return this.$gettext('Abbrechen');
+        },
+
+        showWarning() {
+            // Video is in no playlists
+            if (!Array.isArray(this.event.playlists) || this.event.playlists.length === 0) {
+                return false;
+            }
+
+            // More than one playlist affected
+            if (this.event.playlists.length > 1) {
+                return true;
+            }
+
+            // User contents videos
+            if (!this.playlist) {
+                return true;
+            }
+
+            // Current playlist differs from linked playlist
+            return this.event.playlists[0].token !== this.playlist.token;
+        }
+    },
+
+    methods: {
+        accept() {
+            this.$emit('done');
+        },
+
+        decline() {
+            this.$emit('cancel');
+        },
+    },
+
+    created() {
+        if (!this.showWarning) {
+            this.$emit('done');
+        }
+    }
+}
+</script>

--- a/vueapp/components/Videos/VideoPlaylists.vue
+++ b/vueapp/components/Videos/VideoPlaylists.vue
@@ -1,0 +1,86 @@
+<template>
+    <table class="default" v-if="event.playlists.length > 0">
+        <colgroup>
+            <col>
+            <col style="width: 25%">
+            <col style="width: 25%">
+            <col v-if="removable" style="width: 3%">
+        </colgroup>
+        <thead>
+            <tr>
+                <th>
+                    {{ $gettext('Wiedergabeliste') }}
+                </th>
+                <th>
+                    {{ $gettext('Veranstaltung') }}
+                </th>
+                <th>
+                    {{ $gettext('Semester') }}
+                </th>
+                <th v-if="removable"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr v-for="(playlist, index) in event.playlists" v-bind:key="playlist.id">
+                <td>
+                    <router-link :to="{ name: 'playlist' , params: { token: playlist.token }}" target="_blank">
+                        {{ playlist.title }}
+                    </router-link>
+                </td>
+                <td>
+                    {{ getCourseName(playlist) }}
+                </td>
+                <td>
+                    {{ getSemester(playlist) }}
+                </td>
+                <td v-if="removable">
+                    <studip-icon shape="trash" role="clickable" @click="removePlaylist(index)" style="cursor: pointer"/>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</template>
+
+<script>
+import StudipIcon from '@studip/StudipIcon'
+
+export default {
+    name: 'VideoPlaylists',
+
+    components: { StudipIcon },
+
+    props: {
+        event: Object,
+        removable: {
+            type: Boolean,
+            default: true,
+        },
+    },
+
+    emits: ['removePlaylist'],
+
+    methods: {
+        getCourseName(playlist) {
+            if (!Array.isArray(playlist.courses) || playlist.courses.length === 0) {
+                return '';
+            }
+
+            // Assume a playlist has only one course
+            return playlist.courses[0].name;
+        },
+
+        getSemester(playlist) {
+            if (!Array.isArray(playlist.courses) || playlist.courses.length === 0) {
+                return '';
+            }
+
+            // Assume a playlist has only one course
+            return playlist.courses[0].semester;
+        },
+
+        removePlaylist(index) {
+            this.$emit('removePlaylist', index);
+        },
+    }
+}
+</script>

--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -360,8 +360,8 @@ export default {
                             id: 5,
                             label: this.$gettext('Schnitteditor öffnen'),
                             icon: 'video2',
-                            emit: 'redirectAction',
-                            emitArguments: '/editor/' + this.event.token
+                            emit: 'performAction',
+                            emitArguments: 'VideoCut'
                         });
                     }
 

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -205,6 +205,7 @@ import VideoDeletePermanent from '@/components/Videos/Actions/VideoDeletePermane
 import VideoDownload from '@/components/Videos/Actions/VideoDownload.vue';
 import VideoReport from '@/components/Videos/Actions/VideoReport.vue';
 import VideoEdit from '@/components/Videos/Actions/VideoEdit.vue';
+import VideoCut from '@/components/Videos/Actions/VideoCut.vue';
 import VideoRestore from '@/components/Videos/Actions/VideoRestore.vue';
 import VideoRemoveFromPlaylist from '@/components/Videos/Actions/VideoRemoveFromPlaylist.vue';
 import CaptionUpload from '@/components/Videos/Actions/CaptionUpload.vue';
@@ -227,11 +228,12 @@ export default {
         StudipButton,             VideoLinkToPlaylists,
         VideoAccess,              StudipIcon,
         VideoDownload,            VideoReport,
-        VideoEdit,                VideoRestore,
-        VideoDelete,              VideoDeletePermanent,
-        VideoRemoveFromPlaylist,  CaptionUpload,
-        BulkVideoDelete,          BulkVideoDeletePermanent,
-        BulkVideoRestore,         draggable,
+        VideoEdit,                VideoCut,
+        VideoRestore,             VideoDelete,
+        VideoDeletePermanent,     VideoRemoveFromPlaylist,
+        CaptionUpload,            BulkVideoDelete,
+        BulkVideoDeletePermanent, BulkVideoRestore,
+        draggable,
     },
 
     props: {


### PR DESCRIPTION
Implements the suggestion in https://github.com/elan-ev/studip-opencast-plugin/issues/885.

Changes:
- Add video change warning dialog
- Shows warning when video is in more than two playlists or the current playlist differs from the linked playlist
- No warning is shown if a video is linked with no playlists
- warning is shown before editing video, cutting video and changing video subtitles
- Show linked playlists in dialog of video actions "Zum Löschen markieren" and "Wiederherstellen"

Close #885
