### PR TITLE
Wording of transfer course content action

### DIFF
--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -141,7 +141,7 @@
                         <li v-if="canEdit">
                             <a @click="$emit('copyAll')">
                                 <studip-icon style="margin-left: -20px;" shape="export" role="clickable"/>
-                                {{ $gettext('Videos/Wiedergabelisten übertragen') }}
+                                {{ $gettext('Kursinhalte übertragen') }}
                             </a>
                         </li>
                     </template>


### PR DESCRIPTION
Change the name of course sidebar action "Videos/Wiedergabelisten übertragen" to "Kursinhalte übertragen"

Related to https://github.com/elan-ev/studip-opencast-plugin/issues/879