### PR TITLE
Course Playlist ordering

### DIFF
--- a/lib/Models/Filter.php
+++ b/lib/Models/Filter.php
@@ -16,7 +16,7 @@ class Filter
         $trashed;
 
     private static $ALLOWED_ORDERS = [
-        'created_desc', 'created_asc', 'title_desc', 'title_asc', 'author_desc', 'author_asc', 'order_desc', 'order_asc'
+        'created_desc', 'created_asc', 'title_desc', 'title_asc', 'author_desc', 'author_asc', 'order_desc', 'order_asc', 'mkdate_desc', 'mkdate_asc'
     ];
 
     private static $ALLOWED_FILTERS = [

--- a/lib/Models/Playlists.php
+++ b/lib/Models/Playlists.php
@@ -126,6 +126,9 @@ class Playlists extends UPMap
         $tags      = [];
         $courses   = [];
         $lecturers = [];
+        $orderable_columns = [
+            'mkdate', 'chdate', 'id', 'title', 'author'
+        ];
 
         // Apply filters
         foreach ($filters->getFilters() as $filter) {
@@ -240,8 +243,11 @@ class Playlists extends UPMap
         $stmt->execute($params);
         $count = $stmt->fetchColumn();
 
-        if ($filters->getCourseId()) {
-            $sql .= ' ORDER BY oc_playlist_seminar.is_default DESC';
+        if ($order = $filters->getOrder()) {
+            list($column, $direction) = explode('_', $order, 2);
+            if (!empty($column) && !empty($direction) && in_array($column, $orderable_columns, true)) {
+                $sql .= " ORDER BY oc_playlist.{$column} {$direction}";
+            }
         }
 
         if ($filters->getLimit() != -1) {

--- a/lib/Routes/Course/CourseListPlaylist.php
+++ b/lib/Routes/Course/CourseListPlaylist.php
@@ -37,15 +37,25 @@ class CourseListPlaylist extends OpencastController
             throw new \AccessDeniedException();
         }
 
+        // Order.
+        $params['order'] = 'mkdate_asc';
         // find all playlists of the seminar
         $seminar_playlists = Playlists::getCoursePlaylists($course_id, new Filter($params), $user->id);
         $playlist_list = [];
-
+        // Take default out, and then put it as the first item in array.
+        $default_playlists = null;
         foreach ($seminar_playlists['playlists'] as $seminar_playlist) {
             $data = $seminar_playlist->toSanitizedArray();
 
-            $playlist_list[] = $data;
+            if ((bool) $seminar_playlist->is_default) {
+                $default_playlists = $data;
+            } else {
+                $playlist_list[] = $data;
+            }
         }
+
+        // Here, we put default at first.
+        $playlist_list = array_merge([$default_playlists], $playlist_list);
 
         $courses_ids = PlaylistSeminars::getCoursePlaylistsCourses($course_id);
 


### PR DESCRIPTION
This PR fixes #873,

### Description
there was no ordering when fetching list of course playlists except the one that only ordered the default playlist at the first position.

### Solution
- The `FIlter` class is used and is extended to have `mkdate` column (`Playlist` model uses `mkdate` instead of `created`) as accepted order parameter.
- Upon fetching course playlist, only the filter for ordering "mkdate_asc" is passed, which does the job, and orders the list from old to new top to bottom.
- The concept of putting default playlist is also converted into the code, simply by finding it in the array iteration, taking it out and then merge it at the first position.

### To test
- you would need to create multiple playlists in a course and add link some old ones from the workspace, then just check the ordering based on the old to new top->bottom