### PR TITLE
Responsive Navigation items

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -138,7 +138,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
             $this->_('Opencast Videos'),
             PluginEngine::getURL($this, [], 'course/#/course/videos')
         );
-        $navigation->setImage(Icon::create('video2'));
+        $navigation->setImage(Icon::create('opencast'));
 
         // Get number of new videos since last visit
         $new_videos = Videos::getNumberOfNewCourseVideos($course_id, $last_visit, $user_id);
@@ -149,7 +149,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
             } else {
                 $text = $this->_('neue Videos');
             }
-            $navigation->setImage(Icon::create('video2', Icon::ROLE_ATTENTION, [
+            $navigation->setImage(Icon::create('opencast', Icon::ROLE_ATTENTION, [
                 'title' => $new_videos . ' ' . $text,
             ]));
             $navigation->setBadgeNumber($new_videos);
@@ -186,7 +186,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
             return;
         }
 
-        $title      = 'Opencast Videos';
+        $title = 'Opencast Videos';
         if (SeminarSeries::getVisibilityForCourse($course_id) == 'invisible') {
             $title .= " (" . $this->_('versteckt') . ")";
         }
@@ -195,7 +195,22 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
             $this->_($title),
             PluginEngine::getURL($this, [], 'course#/course/videos')
         );
-        $main->setImage(Icon::create('video2'));
+        $main->setImage(Icon::create('opencast'));
+
+        // We need subnavs in order for responsive view to work properly.
+        $main->addSubNavigation('videos', new Navigation(
+            $this->_('Videos'),
+            PluginEngine::getURL($this, ['target_view' => 'videos'], 'course#/course/videos'),
+        ));
+
+        if ($GLOBALS['perm']->have_studip_perm('tutor', $course_id) &&
+            Config::get()->OPENCAST_ALLOW_SCHEDULER &&
+            Helpers::checkCourseDefaultPlaylist($course_id)) {
+            $main->addSubNavigation('schedule', new Navigation(
+                $this->_('Aufzeichnungen planen'),
+                PluginEngine::getURL($this, ['target_view' => 'schedule'], 'course#/course/schedule')
+            ));
+        }
 
         return ['opencast' => $main];
     }

--- a/app/controllers/course.php
+++ b/app/controllers/course.php
@@ -37,6 +37,25 @@ class CourseController extends Opencast\Controller
         $this->studip_version = $this->getStudIPVersion();
         $this->languages = json_encode($GLOBALS['CONTENT_LANGUAGES']);
 
+        // We need sidebar registration here in php side, in order for responsive navigation to work properly.
+        $this->setSidebar();
+
         $this->render_template('course/index', $GLOBALS['template_factory']->open('layouts/base.php'));
+    }
+
+    /**
+     * Adds the content to sidebar.
+     * @info: The rendered sidebar of this function gets deleted from DOM, because we are using CourseSidebar.vue,
+     * therefore, we only need this to happen in php level!
+     */
+    private function setSidebar()
+    {
+        $sidebar = Sidebar::get();
+
+        $actions = new \TemplateWidget(
+            $this->_('Aktionen'),
+            $this->get_template_factory()->open('course/action_widget')
+        );
+        $sidebar->addWidget($actions);
     }
 }


### PR DESCRIPTION
This PR fixes #868,

### Description
please refer to the issue's description,

### Solution
- In order for Stud.IP to render the navigation of plugins in responsive, it is required to pass them as navigation subs in `getTabNavigation` via `addSubNavigation`.
- In order for Stud.IP to render the sidebar items drawer for the plugin, it is required to add sidebars in the php side via `Sidebar` class -> `addWidget` method.
- In our case, that we use `CourseSidebar.vue` to render everything in one place, we had to delete the Stud.IP rendered sidebar widget.
- To make sure that external links perform and load required data, we had to have a more accurate procedure to handle Views in `CourseSidebar.vue` -> `handleView`
- In Responsive view: in order to toggle the sidebar upon clicks, we are using pure js (exception => there are no other way)

### Extra
- I saw that Opencast Plugin still uses video2 icon, although from StudIP version 5, there is an Opencast icon. Therefore, I have replaced that video2 icon with opencast icon!

### To test
- Make sure you have this PR patched.
- in plugin's root directory perform `npm install && npm run zip`
- Use Responsive Mobile view in your browser or simply use a cell phone to test the plugin, using the navigation tabs etc. to go back and forth and perform every actions within the plugin (login with test_dozent is recommended)