### PR TITLE
Show first copied playlist as default playlist

### DIFF
--- a/lib/Routes/Course/CourseListPlaylist.php
+++ b/lib/Routes/Course/CourseListPlaylist.php
@@ -42,20 +42,17 @@ class CourseListPlaylist extends OpencastController
         // find all playlists of the seminar
         $seminar_playlists = Playlists::getCoursePlaylists($course_id, new Filter($params), $user->id);
         $playlist_list = [];
-        // Take default out, and then put it as the first item in array.
-        $default_playlists = null;
+
         foreach ($seminar_playlists['playlists'] as $seminar_playlist) {
             $data = $seminar_playlist->toSanitizedArray();
 
             if ((bool) $seminar_playlist->is_default) {
-                $default_playlists = $data;
+                // Here, we put default at first.
+                array_unshift($playlist_list, $data);
             } else {
                 $playlist_list[] = $data;
             }
         }
-
-        // Here, we put default at first.
-        $playlist_list = array_merge([$default_playlists], $playlist_list);
 
         $courses_ids = PlaylistSeminars::getCoursePlaylistsCourses($course_id);
 

--- a/vueapp/components/Playlists/PlaylistAddCard.vue
+++ b/vueapp/components/Playlists/PlaylistAddCard.vue
@@ -37,6 +37,7 @@
         />
 
         <PlaylistsCopyCard v-if="activeDialog === 'copy'"
+            :is-default="isDefault"
             @done="done"
             @cancel="cancel"
         />

--- a/vueapp/store/playlists.module.js
+++ b/vueapp/store/playlists.module.js
@@ -170,10 +170,18 @@ const actions = {
     },
 
     async copyPlaylistsToCourse(context, data) {
-        for (const playlist of data.playlists) {
+        for (const [index, playlist] of data.playlists.entries()) {
+            let is_default = false;
+
+            // Set first playlist as default
+            if (data?.is_default === true && index === 0) {
+                is_default = true;
+            }
+
             await context.dispatch('copyPlaylist', {
                 course: data.course,
                 token: playlist,
+                is_default: is_default,
             });
         }
     },
@@ -267,6 +275,7 @@ const actions = {
 
         if (params.course !== undefined) {
             data.course = params.course;
+            data.is_default = params.is_default ?? false;
         }
 
         return ApiService.post('playlists/' + params.token + '/copy', data);


### PR DESCRIPTION
Problem:
- Copy function in new courses without playlists doesn't work because no default course is set. The copied playlists will be copied but not displayed.

Solution:
- Set first copied playlist as default playlist in the course

Additional fix:
- Prevent returned playlist array with null value in `CourseListPlaylist`

Fix #886