### PR TITLE
Fix missing default playlist when transferring course contents

### DIFF
--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -236,7 +236,7 @@ class Helpers
      */
     public static function checkCourseDefaultPlaylist($course_id)
     {
-        $default_playlist = PlaylistSeminars::findOneBySQL('seminar_id = ? AND is_default = 1', [$course_id]);
+        $default_playlist = PlaylistSeminars::getDefaultPlaylistSeminar($course_id);
         return !empty($default_playlist);
     }
 

--- a/lib/Models/PlaylistSeminars.php
+++ b/lib/Models/PlaylistSeminars.php
@@ -44,6 +44,17 @@ class PlaylistSeminars extends \SimpleORMap
     }
 
     /**
+     * Get default playlist seminar of passed course
+     *
+     * @param String $course_id
+     * @return PlaylistSeminars|null
+     */
+    public static function getDefaultPlaylistSeminar(String $course_id)
+    {
+        return self::findOneBySQL('seminar_id = ? AND is_default = 1', [$course_id]);
+    }
+
+    /**
      * Get the courses of the passed video
      *
      * @param Videos $video

--- a/vueapp/components/Videos/Actions/VideoCopyToSeminar.vue
+++ b/vueapp/components/Videos/Actions/VideoCopyToSeminar.vue
@@ -73,7 +73,7 @@ export default {
     },
 
     computed: {
-        ...mapGetters(['userCourses', 'cid', 'courseVideosToCopy']),
+        ...mapGetters(['userCourses', 'cid']),
 
         user_courses_filtered() {
             let userCoursesFiltered = {};
@@ -112,7 +112,6 @@ export default {
             let data = {
                 cid: this.cid,
                 courses: this.courses,
-                tokens: this.courseVideosToCopy
             };
             await this.$store.dispatch('copyVideosToCourses', data)
             .then(({ data }) => {

--- a/vueapp/store/videos.module.js
+++ b/vueapp/store/videos.module.js
@@ -225,13 +225,7 @@ const actions = {
     },
 
     async copyVideosToCourses(context, data) {
-        return ApiService.post('videos/' + data.cid + '/copy',
-            {
-                courses: data.courses,
-                tokens: data?.tokens ?? [],
-                type: data.type,
-            }
-        );
+        return ApiService.post('videos/' + data.cid + '/copy', {courses: data.courses});
     },
 
     async setVideoSort({dispatch, commit}, sort) {


### PR DESCRIPTION
Problem:
- When transfering all contents of a course to a course without default playlist, the playlists are not displayed in the target course because no default playlist is set.

Solution:
- In the above case, set the default playlist of the source course as default playlist in target course.

In addition, unnecessary code is removed.

Fix #879