### PR TITLE
Remove playlist link in playlists table

### DIFF
--- a/vueapp/components/Playlists/PlaylistCard.vue
+++ b/vueapp/components/Playlists/PlaylistCard.vue
@@ -5,13 +5,11 @@
         </td>
 
         <td>
-            <router-link :to="{ name: 'playlist', params: { token: playlist.token } }">
-                {{ playlist.title }}
-                <span v-if="playlist?.default_course_tooltip" class="tooltip tooltip-important" data-tooltip title="" tabindex="0"
-                >
-                    <span class="tooltip-content" v-html="playlist.default_course_tooltip"></span>
-                </span>
-            </router-link>
+            {{ playlist.title }}
+            <span v-if="playlist?.default_course_tooltip" class="tooltip tooltip-important" data-tooltip title="" tabindex="0"
+            >
+                <span class="tooltip-content" v-html="playlist.default_course_tooltip"></span>
+            </span>
 
             <div class="oc--tags oc--tags-playlist">
             <Tag v-for="tag in playlist.tags" v-bind:key="tag.id" :tag="tag.tag" />


### PR DESCRIPTION
The user should not be able to navigate to a playlist in the table as there is currently no place like the workspace to display a playlist which is not connected to the current course.

Fix https://github.com/elan-ev/studip-opencast-plugin/issues/886#issuecomment-1919392099