### PR TITLE
Focus on title input in create playlist dialog

### DIFF
--- a/vueapp/components/Playlists/PlaylistAddNewCard.vue
+++ b/vueapp/components/Playlists/PlaylistAddNewCard.vue
@@ -16,6 +16,7 @@
                     <label>
                         <span class="required">Titel</span>
                         <input type="text"
+                                ref="autofocus"
                                 maxlength="255"
                                 :placeholder="$gettext('Titel der Wiedergabeliste')"
                                 v-model="playlist.title"
@@ -74,6 +75,10 @@ export default {
             this.$store.dispatch('addPlaylist', this.playlist);
             this.$emit('done');
         }
-    }
+    },
+
+    mounted() {
+        this.$refs.autofocus.focus();
+    },
 }
 </script>


### PR DESCRIPTION
Initially focus on title input  in "Wiedergabeliste anlegen" dialog, requested in https://github.com/elan-ev/studip-opencast-plugin/issues/864#issuecomment-1938792737.

Close #864 