### PR TITLE
Upload ACLs for LTI user

### DIFF
--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -295,7 +295,6 @@ export default {
             return window.STUDIP.URLHelper.getURL(
                 server.studio, {
                     'upload.seriesId'  : this.course_config['series']['series_id'],
-                    'upload.acl'       : false,
                     'upload.workflowId': this.getWorkflow(config_id),
                     'return.target'    : window.STUDIP.URLHelper.getURL('plugins.php/opencast/course?cid=' + this.cid),
                     'return.label'     : 'Stud.IP'

--- a/vueapp/components/Videos/VideoUpload.vue
+++ b/vueapp/components/Videos/VideoUpload.vue
@@ -248,11 +248,12 @@ export default {
 
     computed: {
         ...mapGetters({
-            'config'       : 'simple_config_list',
-            'course_config': 'course_config',
-            'cid'          : 'cid',
-            'playlist'     : 'playlist',
-            'playlists'    : 'playlists'
+            'config'        : 'simple_config_list',
+            'course_config' : 'course_config',
+            'cid'           : 'cid',
+            'playlist'      : 'playlist',
+            'playlists'     : 'playlists',
+            'currentLTIUser': 'currentLTIUser'
         }),
 
         upload_playlists() {
@@ -399,9 +400,12 @@ export default {
                 })
             }
 
+            // Opencast LTI info of current user
+            let ltiUploader = this.currentLTIUser[this.selectedServer['id']];
+
             let view = this;
 
-            this.uploadService.upload(files, uploadData, this.selectedWorkflow.name, {
+            this.uploadService.upload(files, uploadData, this.selectedWorkflow.name, ltiUploader, {
                 uploadProgress: (track, loaded, total) => {
                     view.uploadProgress = {
                         flavor: track.flavor,


### PR DESCRIPTION
Problem:
Currently, the processing of uploaded videos fails because the necessary roles and rights to the data are not yet available. This happens especially when the Stud.IP user provider caches the roles of the users but these have not been updated before processing.

Solution:
The role of the current LTI user will be added to the ACLs when the video is uploaded. This change means that the uploader always has read and write access to the video. Currently, this permission can not be removed in the plugin.