### PR TITLE
Enforce standard ACLs for studio uploads

### DIFF
--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -295,6 +295,7 @@ export default {
             return window.STUDIP.URLHelper.getURL(
                 server.studio, {
                     'upload.seriesId'  : this.course_config['series']['series_id'],
+                    'upload.acl'       : true,
                     'upload.workflowId': this.getWorkflow(config_id),
                     'return.target'    : window.STUDIP.URLHelper.getURL('plugins.php/opencast/course?cid=' + this.cid),
                     'return.label'     : 'Stud.IP'


### PR DESCRIPTION
In our OC test system, we had the problem that the setting in Opencast was set to `false`, which caused permission errors in the workflows. With this change, we ensure that the default ACL is always set in Studio.