### PR TITLE
Run workflow on caption upload

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ lti.custom_role_name=Instructor
 lti.custom_roles=ROLE_STUDIO,ROLE_UI_EVENTS_DETAILS_COMMENTS_CREATE,ROLE_UI_EVENTS_DETAILS_COMMENTS_DELETE,ROLE_UI_EVENTS_DETAILS_COMMENTS_EDIT,ROLE_UI_EVENTS_DETAILS_COMMENTS_REPLY,ROLE_UI_EVENTS_DETAILS_COMMENTS_RESOLVE,ROLE_UI_EVENTS_DETAILS_COMMENTS_VIEW,ROLE_UI_EVENTS_DETAILS_MEDIA_VIEW,ROLE_UI_EVENTS_DETAILS_METADATA_EDIT,ROLE_UI_EVENTS_DETAILS_METADATA_VIEW,ROLE_UI_EVENTS_DETAILS_VIEW,ROLE_UI_EVENTS_EDITOR_EDIT,ROLE_UI_EVENTS_EDITOR_VIEW,ROLE_CAPTURE_AGENT,ROLE_API_EVENTS_TRACK_EDIT
 ```
 
-The reference entry in Opencast is neither needed nor wanted, since we are using the Stud.IP user provider. If some actions like ingesting seem to file, when this options is disabled, make sure that the user provider is working correctly. One way to check this, is to call https://opencast.me/info/me.json after opening the videos page in Stud.IP and look for `provider` -> `studip` has to be listed there.  
+The reference entry in Opencast is neither needed nor wanted, since we are using the Stud.IP user provider. If some actions like ingesting seem to file, when this options is disabled, make sure that the user provider is working correctly. One way to check this, is to call https://opencast.me/info/me.json after opening the videos page in Stud.IP and look for `provider` -> `studip` has to be listed there.
 
 4. Edit `/etc/opencast/org.opencastproject.plugin.impl.PluginManagerImpl.cfg` and enable:
 
@@ -72,7 +72,7 @@ Make sure to change the token and add that token to the Opencast config in Stud.
 
 6. Add role `STUDIP` in Opencast
 
-In the Opencast Admin UI, go to Organisation -> Groups and add a group named `STUDIP`. 
+In the Opencast Admin UI, go to Organisation -> Groups and add a group named `STUDIP`.
 
 > :warning: **If you do not add this group, media uploads WILL fail!**
 
@@ -90,6 +90,19 @@ For a good example for an nginx.conf, look at:
 https://github.com/elan-ev/opencast_nginx/blob/main/templates/nginx.conf
 
 ## Opencast Workflows
+
+You can configure which workflow is used for different actions. They can be edited on the plugins admin configuration page. The following table gives an overview of the workflows and their usage / meaning
+
+| Type of workflow | Details      | Allowed Workflow-Tags |
+| ---------------- | ------------ | --------------------- |
+| schedule         | Used for videos which are planned by the scheduling feature  | schedule			  |
+| upload           | Workflow run after uploading a video                         | upload                |
+| studio           | Workflow run after creating a video OC Studio                | upload                |
+| delete           | Workflow run when a video shall be deleted permanently       | delete                |
+| subtiltes        | Workflow run after a subtitle has been added or removed      | archive               |
+
+The subtitles-Workflow needs to make sure that the changes are published, otherwise the subtiltes will not be visible.
+
 
 This plugin assumes your
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -103,12 +103,6 @@ You can configure which workflow is used for different actions. They can be edit
 
 The subtitles-Workflow needs to make sure that the changes are published, otherwise the subtiltes will not be visible.
 
-
-This plugin assumes your
-
-* republish workflow's ID is [`republish-metadata`](https://github.com/elan-ev/studip-opencast-plugin/issues/196)
-* retract workflow's ID is `retract`
-
 ## Credentials for Opencast
 
 This plugin requires an user account to connect to Opencast; create one or use an existing one.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,7 +91,7 @@ https://github.com/elan-ev/opencast_nginx/blob/main/templates/nginx.conf
 
 ## Opencast Workflows
 
-You can configure which workflow is used for different actions. They can be edited on the plugins admin configuration page. The following table gives an overview of the workflows and their usage / meaning
+You can configure which workflow is used for different actions. They can be edited on the plugins admin configuration page. The following table gives an overview of the workflows and their usage / meaning.
 
 | Type of workflow | Details      | Allowed Workflow-Tags |
 | ---------------- | ------------ | --------------------- |
@@ -101,7 +101,7 @@ You can configure which workflow is used for different actions. They can be edit
 | delete           | Workflow run when a video shall be deleted permanently       | delete                |
 | subtiltes        | Workflow run after a subtitle has been added or removed      | archive               |
 
-The subtitles-Workflow needs to make sure that the changes are published, otherwise the subtiltes will not be visible.
+The subtitles-Workflow needs to make sure that the changes are published, otherwise the subtitles will not be visible.
 
 ## Credentials for Opencast
 

--- a/app/controllers/admin.php
+++ b/app/controllers/admin.php
@@ -26,7 +26,7 @@ class AdminController extends Opencast\Controller
     public function index_action()
     {
         $this->studip_version = $this->getStudIPVersion();
-        
+
         Navigation::activateItem('/admin/config/oc-config');
         PageLayout::setBodyElementId('opencast-plugin');
 
@@ -42,6 +42,6 @@ class AdminController extends Opencast\Controller
             PageLayout::postMessage(MessageBox::warning(_('Das Plugin benötigt die "Nobody"-Rolle, um Opencast den Abruf der Nutzendenberechtigungen zu ermöglichen. Diese Rolle wurde jedoch noch nicht zugewiesen, deshalb ist das Plugin momentan nur eingeschränkt funktionsfähig.')));
         }
 
-        WorkflowConfig::createAndUpdateAll();
+        WorkflowConfig::initWorkflows();
     }
 }

--- a/app/controllers/contents.php
+++ b/app/controllers/contents.php
@@ -33,6 +33,13 @@ class ContentsController extends Opencast\Controller
         PageLayout::setBodyElementId('opencast-plugin');
 
         $this->studip_version = $this->getStudIPVersion();
-        $this->languages = json_encode($GLOBALS['CONTENT_LANGUAGES']);
+
+        $languages = [];
+        foreach ($GLOBALS['CONTENT_LANGUAGES'] as $lang => $content) {
+            $languages[str_replace('_', '-', $lang)] = $content;
+        }
+
+        $this->languages = json_encode($languages);
+
     }
 }

--- a/app/controllers/course.php
+++ b/app/controllers/course.php
@@ -35,7 +35,13 @@ class CourseController extends Opencast\Controller
         PageLayout::setBodyElementId('opencast-plugin');
 
         $this->studip_version = $this->getStudIPVersion();
-        $this->languages = json_encode($GLOBALS['CONTENT_LANGUAGES']);
+
+        $languages = [];
+        foreach ($GLOBALS['CONTENT_LANGUAGES'] as $lang => $content) {
+            $languages[str_replace('_', '-', $lang)] = $content;
+        }
+
+        $this->languages = json_encode($languages);
 
         // We need sidebar registration here in php side, in order for responsive navigation to work properly.
         $this->setSidebar();

--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -237,6 +237,15 @@ class Helpers
     public static function checkCourseDefaultPlaylist($course_id)
     {
         $default_playlist = PlaylistSeminars::getDefaultPlaylistSeminar($course_id);
+
+        if (empty($default_playlist)) {
+            // set the first found playlist as default, to prevent breaking the course
+            $stmt = \DBManager::get()->prepare("UPDATE `oc_playlist_seminar` SET is_default = 1 WHERE seminar_id = ? LIMIT 1");
+            $stmt->execute([$course_id]);
+
+            $default_playlist = PlaylistSeminars::getDefaultPlaylistSeminar($course_id);
+        }
+
         return !empty($default_playlist);
     }
 

--- a/lib/Models/WorkflowConfig.php
+++ b/lib/Models/WorkflowConfig.php
@@ -78,7 +78,7 @@ class WorkflowConfig extends \SimpleORMap
             } else {
                 $workflow = Workflow::findOneBySql('config_id = ? AND tag = ?', [$config_id, $type]);
                 if (isset($workflow)) {
-
+                    $entry->setValue('workflow_id', $workflow->id);
                 }
                 else {
                     $entry->setValue('workflow_id', null);

--- a/lib/Models/WorkflowConfig.php
+++ b/lib/Models/WorkflowConfig.php
@@ -7,6 +7,9 @@ use Opencast\Models\Config;
 
 class WorkflowConfig extends \SimpleORMap
 {
+    /**
+     * @inheritDoc
+     */
     protected static function configure($config = [])
     {
         $config['db_table'] = 'oc_workflow_config';
@@ -14,38 +17,74 @@ class WorkflowConfig extends \SimpleORMap
         parent::configure($config);
     }
 
-    public static function createAndUpdateAll($workflows=null) {
+    /**
+     * Create initial workflow configuration for all oc servers
+     *
+     * @param [type] $workflows
+     *
+     * @return void
+     */
+    public static function initWorkflows()
+    {
         $configs = Config::findBySql(1);
         foreach ($configs as $config) {
-            self::createAndUpdateByConfigId($config['id'], $workflows);
+            self::createAndUpdateByConfigId($config['id']);
         }
     }
 
-    public static function createAndUpdateByConfigId($config_id, $workflows=null) {
+    /**
+     * Update mapping of used workflows for passed config
+     *
+     * @param int $config_id
+     * @param Array $workflows
+     *
+     * @return void
+     */
+    public static function createAndUpdateByConfigId($config_id, $workflows = null)
+    {
+        if (empty($config_id)) {
+            return;
+        }
+
+        // var_dump($workflows);
+
         Workflow::updateWorkflowsByConfigId($config_id);
 
         foreach (self::getTypes() as $type) {
             $entry = self::findOneBySql('config_id = ? AND used_for = ?', [$config_id, $type]);
+
             if (!isset($entry)) {
                 $entry = new self();
                 $entry->setValue('config_id', $config_id);
                 $entry->setValue('used_for', $type);
             }
-            
-            $type = ($type == 'studio') ? 'upload' : $type;
-            $workflow_id = isset($workflows[$entry->id]) ? $workflows[$entry->id]['workflow_id'] : $entry->workflow_id;
+
+            switch ($type) {
+                case 'studio';
+                    $type = 'upload';
+                    break;
+
+                case 'subtitles';
+                    $type = 'archive';
+                    break;
+            }
+
+            $workflow_id = isset($workflows[$entry->id])
+                ? $workflows[$entry->id]['workflow_id']
+                : $entry->workflow_id;
+
             if (Workflow::countBySql('config_id = ? AND tag = ? AND id = ?', [$config_id, $type, $workflow_id]) > 0) {
                 $entry->setValue('workflow_id', $workflow_id);
-            }
-            else {
+            } else {
                 $workflow = Workflow::findOneBySql('config_id = ? AND tag = ?', [$config_id, $type]);
                 if (isset($workflow)) {
-                    $entry->setValue('workflow_id', $workflow->id);
+
                 }
                 else {
                     $entry->setValue('workflow_id', null);
                 }
             }
+
             $entry->store();
         }
     }

--- a/lib/Models/WorkflowConfig.php
+++ b/lib/Models/WorkflowConfig.php
@@ -46,8 +46,6 @@ class WorkflowConfig extends \SimpleORMap
             return;
         }
 
-        // var_dump($workflows);
-
         Workflow::updateWorkflowsByConfigId($config_id);
 
         foreach (self::getTypes() as $type) {

--- a/lib/Models/WorkflowConfig.php
+++ b/lib/Models/WorkflowConfig.php
@@ -79,8 +79,7 @@ class WorkflowConfig extends \SimpleORMap
                 $workflow = Workflow::findOneBySql('config_id = ? AND tag = ?', [$config_id, $type]);
                 if (isset($workflow)) {
                     $entry->setValue('workflow_id', $workflow->id);
-                }
-                else {
+                } else {
                     $entry->setValue('workflow_id', null);
                 }
             }

--- a/lib/Routes/Config/SimpleConfigList.php
+++ b/lib/Routes/Config/SimpleConfigList.php
@@ -40,6 +40,7 @@ class SimpleConfigList extends OpencastController
                 'ingest'        => reset(Endpoints::findBySql("config_id = ? AND service_type = 'ingest'", [$conf->id]))->service_url,
                 'apievents'     => reset(Endpoints::findBySql("config_id = ? AND service_type = 'apievents'", [$conf->id]))->service_url,
                 'apiplaylists'  => reset(Endpoints::findBySql("config_id = ? AND service_type = 'apiplaylists'", [$conf->id]))->service_url,
+                'apiworkflows'  => reset(Endpoints::findBySql("config_id = ? AND service_type = 'apiworkflows'", [$conf->id]))->service_url,
                 'studio'        => $conf->service_url . '/studio/index.html',
                 'lti_num'       => sizeof(LtiHelper::getLtiLinks($conf->id))              // used to iterate over all Opencast nodes
             ];

--- a/migrations/093_add_subtitles_workflow.php
+++ b/migrations/093_add_subtitles_workflow.php
@@ -1,0 +1,24 @@
+<?php
+
+class AddSubtitlesWorkflow extends Migration
+{
+    public function description()
+    {
+        return 'Remove "editor" from list of configurable workflows';
+    }
+
+    public function up()
+    {
+        $db = DBManager::get();
+
+        $db->exec("ALTER TABLE `oc_workflow_config`
+            MODIFY `used_for` enum('schedule','upload','studio','delete','subtitles')
+        ");
+
+        SimpleOrMap::expireTableScheme();
+    }
+
+    public function down()
+    {
+    }
+}

--- a/vueapp/common/upload.service.js
+++ b/vueapp/common/upload.service.js
@@ -44,7 +44,7 @@ class UploadService {
                         <SubjectAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:subject:role" DataType="http://www.w3.org/2001/XMLSchema#string"/>
                     </Apply>
                 </Condition>
-            </Rule> 
+            </Rule>
             <Rule RuleId="ROLE_ADMIN_read_write_Permit" Effect="Permit">
                 <Target>
                     <Actions>
@@ -234,7 +234,7 @@ class UploadService {
                 var data = new FormData();
                 data.append('mediaPackage', mediaPackage);
                 data.append('flavor', file.flavor);
-                data.append('tags', '');
+                data.append('tags', file.tag);
                 data.append('BODY', file.file, file.file.name);
 
                 return obj.addTrack(data, obj.service_urls['ingest'] + "/addTrack", file, onProgress);
@@ -244,6 +244,7 @@ class UploadService {
 
     async uploadCaptions(files, episode_id, workflowId, options) {
         this.fixFilenames(files);
+
         let onProgress = options.uploadProgress;
         let uploadDone = options.uploadDone;
         let onError = options.onError;
@@ -256,6 +257,7 @@ class UploadService {
                 data.append('flavor', file.flavor);
                 data.append('overwriteExisting', file.overwriteExisting);
                 data.append('track', file.file);
+                data.append('tags', file.tag);
 
                 return obj.addTrack(data, obj.service_urls['apievents'] + "/" + episode_id + "/track", file, onProgress, onError);
             });

--- a/vueapp/common/upload.service.js
+++ b/vueapp/common/upload.service.js
@@ -7,8 +7,8 @@
 import axios from "@/common/axios.service";
 class UploadService {
 
-    constructor(service_url) {
-        this.service_url = service_url;
+    constructor(service_urls) {
+        this.service_urls = service_urls;
     }
 
     /**
@@ -158,7 +158,7 @@ class UploadService {
     async getMediaPackage() {
         return axios({
             method: 'GET',
-            url: this.service_url + "/createMediaPackage",
+            url: this.service_urls['ingest'] + "/createMediaPackage",
             crossDomain: true,
             withCredentials: true,
             headers: {
@@ -194,7 +194,7 @@ class UploadService {
         let episodeDC = this.createDCCCatalog(terms);
 
         return axios({
-            url: this.service_url + "/addDCCatalog",
+            url: this.service_urls['ingest'] + "/addDCCatalog",
             method: "POST",
             data: new URLSearchParams({
                 mediaPackage: mediaPackage,
@@ -216,7 +216,7 @@ class UploadService {
         acldata.append('BODY', new Blob([acl]), 'acl.xml');
 
         return axios({
-            url: this.service_url + "/addAttachment",
+            url: this.service_urls['ingest'] + "/addAttachment",
             method: "POST",
             data: acldata,
             processData: false,
@@ -237,7 +237,7 @@ class UploadService {
                 data.append('tags', '');
                 data.append('BODY', file.file, file.file.name);
 
-                return obj.addTrack(data, "/addTrack", file, onProgress);
+                return obj.addTrack(data, obj.service_urls['ingest'] + "/addTrack", file, onProgress);
             });
         }, Promise.resolve(mediaPackage))
     }
@@ -257,7 +257,7 @@ class UploadService {
                 data.append('overwriteExisting', file.overwriteExisting);
                 data.append('track', file.file);
 
-                return obj.addTrack(data, "/" + episode_id + "/track", file, onProgress, onError);
+                return obj.addTrack(data, obj.service_urls['apievents'] + "/" + episode_id + "/track", file, onProgress, onError);
             });
         }, Promise.resolve())
         .then(() => {
@@ -273,9 +273,8 @@ class UploadService {
     }
 
     runWorkflow(episode_id, workflowId) {
-        console.log("hi");
         return axios({
-            url: this.service_url + "/api/workflows",
+            url: this.service_urls['apiworkflows'],
             method: "POST",
             data: new URLSearchParams({
                 event_identifier: episode_id,
@@ -288,7 +287,7 @@ class UploadService {
         })
     }
 
-    addTrack(data, url_path, track, onProgress, onError) {
+    addTrack(data, oc_url, track, onProgress, onError) {
         var fnOnProgress = function (event) {
             onProgress(track, event.loaded, event.total);
         };
@@ -300,7 +299,7 @@ class UploadService {
                 obj.request = axios.CancelToken.source();
 
                 return axios({
-                    url: obj.service_url + url_path,
+                    url: oc_url,
                     method: "POST",
                     data: data,
                     processData: false,
@@ -321,7 +320,7 @@ class UploadService {
 
     finishIngest(mediaPackage, workflowId = "upload") {
         return axios({
-            url: this.service_url + "/ingest",
+            url: this.service_urls['ingest'] + "/ingest",
             method: "POST",
             data: new URLSearchParams({
                 mediaPackage: mediaPackage,

--- a/vueapp/common/upload.service.js
+++ b/vueapp/common/upload.service.js
@@ -242,7 +242,7 @@ class UploadService {
         }, Promise.resolve(mediaPackage))
     }
 
-    async uploadCaptions(files, episode_id, options) {
+    async uploadCaptions(files, episode_id, workflowId, options) {
         this.fixFilenames(files);
         let onProgress = options.uploadProgress;
         let uploadDone = options.uploadDone;
@@ -261,12 +261,31 @@ class UploadService {
             });
         }, Promise.resolve())
         .then(() => {
-            uploadDone();
+            return this.runWorkflow(episode_id, workflowId)
+            .then(function ({ data }) {
+                uploadDone();
+            })
         }).catch(function (error) {
             if (error.code === 'ERR_NETWORK') {
                 onError();
             }
         });
+    }
+
+    runWorkflow(episode_id, workflowId) {
+        console.log("hi");
+        return axios({
+            url: this.service_url + "/api/workflows",
+            method: "POST",
+            data: new URLSearchParams({
+                event_identifier: episode_id,
+                workflow_definition_identifier: workflowId
+            }),
+            withCredentials: true,
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+            }
+        })
     }
 
     addTrack(data, url_path, track, onProgress, onError) {

--- a/vueapp/components/Config/WorkflowOptions.vue
+++ b/vueapp/components/Config/WorkflowOptions.vue
@@ -40,7 +40,12 @@ export default {
                         let options = [];
                         for (let wf of this.simple_config_list.workflows) {
                             if (wf['config_id'] == config_id &&
-                                (wf['tag'] === wf_conf['used_for'] || wf['tag'] === 'upload' && wf_conf['used_for'] === 'studio')) {
+                                (
+                                    wf['tag'] === wf_conf['used_for']
+                                    || wf['tag'] === 'upload' && wf_conf['used_for'] === 'studio'
+                                    || wf['tag'] === 'archive' && wf_conf['used_for'] === 'subtitles'
+                                )
+                            ) {
                                 options.push({
                                     'value': wf['id'],
                                     'description': wf['displayname']

--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -72,7 +72,9 @@
                                             {{ $gettext('Untertiteldatei auswählen') }}
                                         </StudipButton>
                                         <input
-                                            type="file" class="caption_upload" :data-flavor="language.flavor"
+                                            type="file" class="caption_upload"
+                                            :data-flavor="language.flavor"
+                                            :data-tag="language.tag"
                                             @change="previewFiles" :ref="'oc-file-' + language.lang"
                                             accept=".vtt"
                                         >
@@ -212,11 +214,12 @@ export default {
                         'apiworkflows': this.selectedServer['apiworkflows'],
                     });
 
-                    this.uploadService.uploadCaptions(files, this.event.episode, {
+                    this.uploadService.uploadCaptions(files, this.event.episode, this.defaultWorkflow.name, {
                         uploadProgress: () => {},
                         uploadDone: () => {
                             delete view.files[flavor]
-                    }})
+                        }
+                    });
                 } else {
                     delete this.files[flavor]
                 }
@@ -269,6 +272,7 @@ export default {
                     files.push({
                         file: value['file'],
                         flavor: key,
+                        tag: value['tag'],
                         overwriteExisting: true,
                         progress: {
                             loaded: 0,
@@ -315,12 +319,15 @@ export default {
 
         previewFiles(event) {
             let flavor = event.target.attributes['data-flavor'].value;
+            let tag    = event.target.attributes['data-tag'].value;
+
             let language = this.languages.find(language => language.flavor === flavor).lang;
 
             this.files[flavor] = {
                 name: event.target.files[0].name,
                 size: this.$filters.filesize(event.target.files[0].size),
-                file: event.target.files[0]
+                file: event.target.files[0],
+                tag:  tag
             }
         }
     },
@@ -336,7 +343,7 @@ export default {
         for (let key in window.OpencastPlugin.STUDIP_LANGUAGES) {
             this.languages.push({
                 lang: window.OpencastPlugin.STUDIP_LANGUAGES[key].name,
-                flavor: 'captions/source',
+                flavor: 'captions/prepared',
                 tag: 'lang:' + key
             });
         }

--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -25,7 +25,7 @@
                 <form class="default" style="max-width: 50em;" ref="upload-form">
                     <fieldset>
                         <legend >
-                                {{ $gettext('Datei(en)') }}
+                                {{ $gettext('Untertiteldatei(en)') }} - {{ $gettext('Workflow') }}: {{ defaultWorkflow.displayname }}
                         </legend>
 
                         <p class="help">
@@ -102,6 +102,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import { toRaw } from "vue";
 
 import StudipDialog from '@studip/StudipDialog'
 import StudipButton from '@studip/StudipButton'
@@ -166,12 +167,19 @@ export default {
         },
 
         defaultWorkflow() {
-            let wf_id = this.config['workflow_configs'].find(wf_config =>
+
+            let workflow = this.config['workflow_configs'].find(wf_config =>
                 wf_config['config_id'] == this.config.settings['OPENCAST_DEFAULT_SERVER']
                     && wf_config['used_for'] === 'subtitles'
-            )['workflow_id'];
+            )
 
-            return this.config['workflows'].find(wf => wf['id'] == wf_id);
+            if (workflow) {
+                let wf_id = workflow['workflow_id'];
+
+                return this.config['workflows'].find(wf => wf['id'] == wf_id);
+            }
+
+            return 'republish-metadata';
         },
 
         upload_workflows() {

--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -80,20 +80,6 @@
                                 </div>
                             </fieldset>
 
-                            <fieldset>
-                                <legend >
-                                    {{ $gettext('Workflow') }}
-                                </legend>
-
-                                <select v-model="selectedWorkflow" required>
-                                    <option v-for="workflow in upload_workflows"
-                                        v-bind:key="workflow.id"
-                                        :value="workflow">
-                                        {{ workflow.displayname }}
-                                    </option>
-                                </select>
-                            </fieldset>
-
                             <ProgressBar v-if="uploadProgress && uploadProgress.flavor == language.flavor" :progress="uploadProgress.progress" />
                         </div>
                     </fieldset>
@@ -150,8 +136,7 @@ export default {
             fileUploadError: false,
             files: {},
             uploadProgress: null,
-            languages: [],
-            selectedWorkflow: false
+            languages: []
         }
     },
 
@@ -183,7 +168,7 @@ export default {
         defaultWorkflow() {
             let wf_id = this.config['workflow_configs'].find(wf_config =>
                 wf_config['config_id'] == this.config.settings['OPENCAST_DEFAULT_SERVER']
-                    && wf_config['used_for'] === 'upload'
+                    && wf_config['used_for'] === 'subtitles'
             )['workflow_id'];
 
             return this.config['workflows'].find(wf => wf['id'] == wf_id);
@@ -281,7 +266,7 @@ export default {
 
             let view = this;
 
-            this.uploadService.uploadCaptions(files, this.event.episode, this.selectedWorkflow.name, {
+            this.uploadService.uploadCaptions(files, this.event.episode, this.defaultWorkflow.name, {
                     uploadProgress: (track, loaded, total) => {
                         view.uploadProgress = {
                             flavor: track.flavor,
@@ -330,7 +315,6 @@ export default {
         this.$store.dispatch('authenticateLti');
         this.$store.dispatch('simpleConfigListRead').then(() => {
             this.selectedServer = this.config['server'][this.config.settings['OPENCAST_DEFAULT_SERVER']];
-            this.selectedWorkflow = this.defaultWorkflow;
         });
         this.$store.dispatch('loadCaption', this.event.token);
 

--- a/vueapp/components/Videos/Actions/CaptionUpload.vue
+++ b/vueapp/components/Videos/Actions/CaptionUpload.vue
@@ -207,7 +207,10 @@ export default {
                 if (this.files[flavor].url) {
                     let view = this;
                     // get correct upload endpoint url
-                    this.uploadService = new UploadService(this.selectedServer['apievents']);
+                    this.uploadService = new UploadService({
+                        'apievents':    this.selectedServer['apievents'],
+                        'apiworkflows': this.selectedServer['apiworkflows'],
+                    });
 
                     this.uploadService.uploadCaptions(files, this.event.episode, {
                         uploadProgress: () => {},
@@ -255,7 +258,10 @@ export default {
             }
 
             // get correct upload endpoint url
-            this.uploadService = new UploadService(this.selectedServer['apievents']);
+            this.uploadService = new UploadService({
+                'apievents':    this.selectedServer['apievents'],
+                'apiworkflows': this.selectedServer['apiworkflows'],
+            });
 
             let files = [];
             for (const [key, value] of Object.entries(this.files)) {
@@ -330,7 +336,8 @@ export default {
         for (let key in window.OpencastPlugin.STUDIP_LANGUAGES) {
             this.languages.push({
                 lang: window.OpencastPlugin.STUDIP_LANGUAGES[key].name,
-                flavor: 'captions/source+' + key.split('_')[0]
+                flavor: 'captions/source',
+                tag: 'lang:' + key
             });
         }
     },

--- a/vueapp/components/Videos/VideoUpload.vue
+++ b/vueapp/components/Videos/VideoUpload.vue
@@ -375,7 +375,9 @@ export default {
             }
 
             // get correct upload endpoint url
-            this.uploadService = new UploadService(this.selectedServer['ingest']);
+            this.uploadService = new UploadService({
+                'ingest': this.selectedServer['ingest']
+            });
 
             let uploadData         = this.upload;
 


### PR DESCRIPTION
Ref #355 

- Workflow selection im CaptionUpload Dialog
- Tag=upload wird angezeigt, evtl ändern?
- Bei erfolgreichem upload der caption wird dann /api/workflows mit dem event_identifier und dem ausgewähltem Workflow angestoßen

- Caption wird als track mit flavour "captions/source+\<lang\>" hinzugefügt
  - Beim anstoß eines workflows (fast) wird die caption in meinem Testsystem nicht übernommen
  - https://github.com/opencast/opencast/issues/4407
  - Dort wird gesagt, dass die Sprache über einen tag "lang:\<language\>" angegeben werden sollte
    - Ist das so aktuell?
    - In meinem Testsystem kann ich über "POST /{eventId}/track" keine Tags mitgeben, müsste man nochmal prüfen