### PR TITLE
Port lti iframe to v2

### DIFF
--- a/classes/lti/LtiHelper.php
+++ b/classes/lti/LtiHelper.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Opencast\LTI;
+
+use Opencast\Models\OCConfig as Config;
+use Opencast\Models\OCEndpoints as Endpoints;
+use OCPerm as Perm;
+
+/**
+ * LTI Helper class to create launch data
+ */
+class LtiHelper
+{
+    /**
+     * Returns an array of LtiLink-objects for every possible endpoint url
+     * for the config with the passed config_id
+     *
+     * @param  int  $config_id   config to check
+     *
+     * @return Array            array of LtiLink
+     */
+    public static function getLtiLinks($config_id)
+    {
+        $links = [];
+        $endpoints = Endpoints::findByConfig_id($config_id);
+        $config    = Config::find($config_id);
+
+        foreach ($endpoints as $endpoint) {
+            // skip 'services' endpoints
+            if ($endpoint->service_type == 'services') {
+                continue;
+            }
+
+            $url = parse_url($endpoint['service_url']);
+
+            $lti_url = $url['scheme'] . '://'. $url['host']
+                . ($url['port'] ? ':' . $url['port'] : '') . '/lti';
+
+            if (!$links[$lti_url]) {
+                $links[$lti_url] = [
+                    'link' => new LtiLink(
+                        $lti_url,
+                        $config->settings['lti_consumerkey'],
+                        $config->settings['lti_consumersecret']
+                    ),
+                    'endpoints'   => [$endpoint->service_type],
+                ];
+            } else {
+                $links[$lti_url]['endpoints'][] = $endpoint->service_type;
+            }
+        }
+
+        return $links;
+    }
+
+    /**
+     * Return basic launch data for every distinct endpoint url for the config
+     * with the passed config_id
+     *
+     * @param  int  $config_id   config to check
+     * @param  string  $custom_tool the custom tool parameter
+     * @param  object  $video_share  the video share object
+     * @return Array             array of LtiLink
+     */
+    public static function getLaunchData($config_id, $custom_tool = '/ltitools', $video_share = null)
+    {
+        global $user;
+
+        $lti_links = [];
+
+        foreach(self::getLtiLinks($config_id) as $lti) {
+            if (!empty($video_share)) {
+                $lti['link']->setSharedUser($video_share);
+            } else {
+                $lti['link']->setUser($user->id, 'Instructor', true);
+            }
+
+            if (!empty($custom_tool)) {
+                $lti['link']->addCustomParameter('tool', urlencode($custom_tool));
+            }
+            $launch_data = $lti['link']->getBasicLaunchData();
+            $signature   = $lti['link']->getLaunchSignature($launch_data);
+
+            $launch_data['oauth_signature'] = $signature;
+
+            $lti_links[] = [
+                'launch_url'  => $lti['link']->getLaunchURL(),
+                'launch_data' => $launch_data,
+                'endpoints'   => $lti['endpoints'],
+                'config_id'   => $config_id
+            ];
+        }
+
+        return $lti_links;
+    }
+
+    /**
+     * Return launch data with user and course for every distinct endpoint url
+     * for the config with the passed config_id
+     *
+     * @param  int  $config_id                 config to check
+     * @param  string $course_id               course_id to add to lti call
+     * @param  string $user_id                 optional, defaults to $GLOBALS['user']->id;
+     *
+     * @return Array             array of LtiLink
+     */
+    public static function getLaunchDataForCourse($config_id, $course_id, $user_id = null)
+    {
+        global $user, $perm;
+
+        if (!$user_id) {
+            $user_id = $user->id;
+        }
+
+        $role = Perm::editAllowed($course_id, $user_id)
+            ? 'Instructor' : 'Learner';
+
+        $lti_links = [];
+
+        foreach(self::getLtiLinks($config_id) as $lti) {
+            $lti['link']->setUser($user_id, $role, true);
+            $lti['link']->setCourse($course_id);
+
+            $launch_data = $lti['link']->getBasicLaunchData();
+            $signature   = $lti['link']->getLaunchSignature($launch_data);
+
+            $launch_data['oauth_signature'] = $signature;
+
+            $lti_links[] = [
+                'launch_url'  => $lti['link']->getLaunchURL(),
+                'launch_data' => $launch_data,
+                'endpoints'   => $lti['endpoints'],
+                'config_id'   => $config_id
+            ];
+        }
+
+        return $lti_links;
+    }
+}

--- a/controllers/redirect.php
+++ b/controllers/redirect.php
@@ -3,6 +3,7 @@
 use Opencast\Models\OCSeminarEpisodes;
 use Opencast\Models\OCSeminarSeries;
 use Opencast\Models\OCEndpoints;
+use Opencast\LTI\LtiHelper;
 
 class RedirectController extends OpencastController
 {
@@ -25,5 +26,38 @@ class RedirectController extends OpencastController
             . ($url['port'] ? ':' . $url['port'] : '') . "/play/{$episode_id}";
 
         $this->redirect($play_url);
+    }
+
+
+    /**
+     * Directly redirect to passed LTI endpoint
+     *
+     * @param [type] $launch_url
+     * @param [type] $launch_data
+     *
+     * @return void
+     */
+    public function authenticate_action($num)
+    {
+        $course_id = Context::getId();
+        $config_id = Request::int('config_id');
+
+        if (empty($config_id)) {
+            throw new \Exception('missing or wrong config id!');
+        }
+
+        if ($course_id) {
+            $lti = LtiHelper::getLaunchDataForCourse($config_id, $course_id);
+
+        } else {
+            $lti = LtiHelper::getLaunchData($config_id);
+        }
+
+        if (empty($lti[$num])) {
+            throw new \Exception('error creating lti call');
+        }
+
+        $this->launch_data = $lti[$num]['launch_data'];
+        $this->launch_url  = $lti[$num]['launch_url'];
     }
 }

--- a/models/Pager.php
+++ b/models/Pager.php
@@ -104,7 +104,7 @@ class Pager
      * @param String $string String to translate
      * @return translated string
      */
-    public function _($string)
+    public static function _($string)
     {
         $result = \OpenCast::GETTEXT_DOMAIN === null
             ? $string

--- a/views/course/_lti.php
+++ b/views/course/_lti.php
@@ -1,0 +1,16 @@
+<?
+$config = Opencast\Models\OCConfig::findBySql(1);
+foreach ($config as $conf) :
+    // iterate over all opencast nodes for this server as well
+    $num = 0;
+    foreach (Opencast\LTI\LtiHelper::getLtiLinks($conf->id) as $link) : ?>
+        <iframe
+            height="0" width="0" style="border: 0px"
+            src="<?= \PluginEngine::getURL('opencast', [
+                'config_id' => $conf->id,
+                'cid'       => Context::getId()
+            ], 'redirect/authenticate/' . $num, true) ?>">
+        </iframe>
+        <? $num++ ?>
+    <? endforeach ?>
+<? endforeach ?>

--- a/views/course/index.php
+++ b/views/course/index.php
@@ -6,6 +6,7 @@ use Opencast\Models\Pager;
 
 ?>
 
+<?= $this->render_partial('course/_lti.php') ?>
 <? $studygroup_active = true; ?>
 <? if ($flash['delete']) : ?>
     <?= $params = [

--- a/views/redirect/authenticate.php
+++ b/views/redirect/authenticate.php
@@ -1,0 +1,11 @@
+<form class="default" action="<?= htmlspecialchars($launch_url) ?>" name="ltiLaunchForm" id="ltiLaunchForm" method="post" encType="application/x-www-form-urlencoded">
+    <? foreach ($launch_data as $name => $value) : ?>
+        <input type="hidden" name="<?= htmlspecialchars($name) ?>" value="<?= htmlspecialchars($value) ?>">
+    <? endforeach ?>
+</form>
+
+<script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        $('#ltiLaunchForm').submit();
+    });
+</script>


### PR DESCRIPTION
Due to the firefox tracking prevention, LTI calls do not work if Opencast resides on another TLD. This MR tries to circumvent this by using iframes, like in V3 of the plugin.