### PR TITLE
Avoid PHP Warning "Undefined global variable"

### DIFF
--- a/OpenCast.class.php
+++ b/OpenCast.class.php
@@ -65,7 +65,7 @@ class OpenCast extends StudipPlugin implements SystemPlugin, StandardPlugin, Cou
             }
         }
 
-        if (!$GLOBALS['opencast_already_loaded']) {
+        if (empty($GLOBALS['opencast_already_loaded'])) {
             $this->addStylesheet('stylesheets/oc.less');
             PageLayout::addScript($this->getPluginUrl() . '/static/application.js');
 


### PR DESCRIPTION
When using the plugin under PHP `8.3.6-0ubuntu0.24.04.1` with Stud.IP 5.4 we see the following warning on every page: **Warning**: Undefined global variable `$opencast_already_loaded` in **/data/studip/public/plugins_packages/elan-ev/OpenCast/OpenCast.class.php** on line **68**

This (HTML) warning breaks JSON and binary outputs, for instance, the dynamically loaded course list.

Our support suggested changing this line as in this PR.