### PR TITLE
Disable page layout when loading the player

### DIFF
--- a/app/controllers/redirect.php
+++ b/app/controllers/redirect.php
@@ -67,9 +67,10 @@ class RedirectController extends Opencast\Controller
         $this->launch_url  = $ltilink['launch_url'];
 
         if (!empty($this->error)) {
-            $this->set_layout(null);
             $this->assets_url = rtrim($this->plugin->getPluginUrl(), '/') . '/assets';
         }
+
+        $this->set_layout(null);
     }
 
     /**

--- a/app/views/redirect/perform.php
+++ b/app/views/redirect/perform.php
@@ -1,6 +1,6 @@
-<? if (!empty($this->error)) : ?>
 <DOCTYPE html>
 <html>
+<? if (!empty($this->error)) : ?>
     <head>
         <style>
             h1 {
@@ -26,20 +26,20 @@
             <?= htmlReady($this->error) ?>
         </h1>
     </body>
-</html>
 <? else : ?>
-<form class="default" action="<?= $launch_url ?>" name="ltiLaunchForm" id="ltiLaunchForm" method="post" encType="application/x-www-form-urlencoded">
-    <div class="oc--loading-spinner oc--loading-redirect">
-        <div class="oc--spinner"></div>
-    </div>
-    <? foreach ($launch_data as $name => $value) : ?>
-        <input type="hidden" name="<?= htmlspecialchars($name) ?>" value="<?= htmlspecialchars($value) ?>">
-    <? endforeach ?>
-</form>
-
-<script type="text/javascript">
-    jQuery(function ($) {
-        $('#ltiLaunchForm').submit();
-    });
-</script>
+    <head>
+        <script type="text/javascript">
+            document.addEventListener("DOMContentLoaded", function () {
+                document.getElementById('ltiLaunchForm').submit();
+            });
+        </script>
+    </head>
+    <body>
+        <form class="default" action="<?= $launch_url ?>" name="ltiLaunchForm" id="ltiLaunchForm" method="post" encType="application/x-www-form-urlencoded">
+            <? foreach ($launch_data as $name => $value) : ?>
+                <input type="hidden" name="<?= htmlspecialchars($name) ?>" value="<?= htmlspecialchars($value) ?>">
+            <? endforeach ?>
+        </form>
+    </body>
 <? endif ?>
+</html>


### PR DESCRIPTION
Diese Änderungen verhindern das Anzeigen der Stud.IP-Seite beim Laden eines Videos, sodass der Übergang zwischen Stud.IP und Player geschmeidiger ablaufen soll.

Altes Verhalten (Dark-Theme im Browser):

[Screencast from 2024-11-05 13-35-24.webm](https://github.com/user-attachments/assets/d171e7a6-6807-4c5a-8749-8096e1e30b24)

Altes Verhalten (Light-Theme im Browser):

[Screencast from 2024-11-05 13-37-56.webm](https://github.com/user-attachments/assets/b78dda78-2735-4be8-9655-6258ebe9036a)

Neues Verhalten (Dark-Theme im Browser):

[Screencast from 2024-11-05 13-36-17.webm](https://github.com/user-attachments/assets/48b6992c-c4fa-4bfd-8b07-3632e055b4cf)

Neues Verhalten (Light-Theme im Browser):

[Screencast from 2024-11-05 13-36-56.webm](https://github.com/user-attachments/assets/baf20e9e-9769-4d9b-93e2-a9791beb585e)

Teilt gerne mit, ob ihr dieses Verhalten oder das alte Verhalten präferiert.