### PR TITLE
Fix null error if no default server exists

### DIFF
--- a/lib/Routes/Config/ConfigList.php
+++ b/lib/Routes/Config/ConfigList.php
@@ -56,7 +56,9 @@ class ConfigList extends OpencastController
 
 
 
-        if (!PlaylistMigration::isConverted() && count($config_list) &&
+        if (!PlaylistMigration::isConverted() &&
+            count($config_list) &&
+            \Config::get()->OPENCAST_DEFAULT_SERVER != -1 &&
             version_compare(
                 OCConfig::getOCBaseVersion(\Config::get()->OPENCAST_DEFAULT_SERVER),
                 '16',


### PR DESCRIPTION
Add check if default config is not `-1` to prevent null errors. 

Fix #1056