### PR TITLE
Log php exceptions in slim routes

### DIFF
--- a/lib/Errors/ExceptionHandler.php
+++ b/lib/Errors/ExceptionHandler.php
@@ -37,6 +37,9 @@ class ExceptionHandler
 
             $errors->add($exception);
         } else {
+            // Log always php exceptions
+            error_log($exception);
+
             $httpCode = 500;
             $details = null;
 


### PR DESCRIPTION
Json api error messages on our test system are not helpful, as no traceback is shown in the error log nor in the client. This change writes all PHP exceptions throwing in the JSON API to the error logs on the server. 