### PR TITLE
Remove anonymous role if video visibility is changed to internal

### DIFF
--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -334,6 +334,10 @@ class Helpers
 
         $possible_roles = array_column($studip_acls, 'role');
 
+        if (\Config::get()->OPENCAST_ALLOW_PUBLIC_SHARING) {
+            $possible_roles[] = 'ROLE_ANONYMOUS';
+        }
+
         sort($acls);
 
         $result = [];


### PR DESCRIPTION
Currently, the role `ROLE_ANONYMOUS` will not be removed when updating the ACLs, as it is evaluated as an external OC role. With this change, this role will be touched, if the setting `OPENCAST_ALLOW_PUBLIC_SHARING` is active.

Fixes #1031