### PR TITLE
Fix broken urls due to renaming

### DIFF
--- a/courseware/vueapp/courseware-plugin-opencast-video.vue
+++ b/courseware/vueapp/courseware-plugin-opencast-video.vue
@@ -177,7 +177,7 @@ export default {
 
         performSelectVideo(video) {
             this.currentVideoId = video.token;
-            this.currentEpisodeURL = STUDIP.ABSOLUTE_URI_STUDIP + 'plugins.php/opencast/redirect/perform/video/' + video.token;
+            this.currentEpisodeURL = STUDIP.ABSOLUTE_URI_STUDIP + 'plugins.php/opencastv3/redirect/perform/video/' + video.token;
             this.currentVisible = video?.visibility || 'public';
         },
 
@@ -208,7 +208,7 @@ export default {
 
         initCurrentData() {
             this.currentVideoId = get(this.block, "attributes.payload.token", "");
-            this.currentEpisodeURL =STUDIP.ABSOLUTE_URI_STUDIP + 'plugins.php/opencast/redirect/perform/video/' + this.currentVideoId;
+            this.currentEpisodeURL =STUDIP.ABSOLUTE_URI_STUDIP + 'plugins.php/opencastv3/redirect/perform/video/' + this.currentVideoId;
             this.currentVisible = get(this.block, "attributes.payload.visible", "");
 
             let copied_from = get(this.block, "attributes.payload.copied_from", "");

--- a/lib/Models/VideosUserPerms.php
+++ b/lib/Models/VideosUserPerms.php
@@ -121,7 +121,7 @@ class VideosUserPerms extends \SimpleORMap
                     // notify user, that one of his videos is now available
                     \PersonalNotifications::add(
                         $user_id,
-                        \URLHelper::getURL('plugins.php/opencast/contents/index', [], true),
+                        \URLHelper::getURL('plugins.php/opencastv3/contents/index', [], true),
                         sprintf(_('Das Video mit dem Titel "%s" wurde fertig verarbeitet.'), $episode->title),
                         "opencast_" . $episode->identifier,
                         \Icon::create('video'),

--- a/lib/Routes/Video/VideoSharesList.php
+++ b/lib/Routes/Video/VideoSharesList.php
@@ -45,7 +45,7 @@ class VideoSharesList extends OpencastController
         $old_url_helper_url = \URLHelper::setBaseURL($GLOBALS['ABSOLUTE_URI_STUDIP']);
         foreach ($video->shares->toArray() as $share) {
             $share['link'] = \URLHelper::getURL(
-                "plugins.php/opencast/redirect/perform/share/{$share['token']}",
+                "plugins.php/opencastv3/redirect/perform/share/{$share['token']}",
                 ['cancel_login' => 1]
             );
             $shares[] = $share;

--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -316,7 +316,7 @@ export default {
                     'upload.seriesId'  : this.course_config['series']['series_id'],
                     'upload.acl'       : true,
                     'upload.workflowId': this.getWorkflow(config_id),
-                    'return.target'    : window.STUDIP.URLHelper.getURL('plugins.php/opencast/course?cid=' + this.cid),
+                    'return.target'    : window.STUDIP.URLHelper.getURL('plugins.php/opencastv3/course?cid=' + this.cid),
                     'return.label'     : 'Stud.IP'
                 }
             );

--- a/vueapp/components/Playlists/PlaylistAddToCourseDialog.vue
+++ b/vueapp/components/Playlists/PlaylistAddToCourseDialog.vue
@@ -82,7 +82,7 @@ export default {
 
     methods: {
         getCourseLink(course) {
-            return window.STUDIP.URLHelper.getURL('plugins.php/opencast/course?cid=' + course.id + '#/course/videos')
+            return window.STUDIP.URLHelper.getURL('plugins.php/opencastv3/course?cid=' + course.id + '#/course/videos')
         },
 
         addCourse(course) {

--- a/vueapp/components/Videos/Actions/VideoCopyToSeminar.vue
+++ b/vueapp/components/Videos/Actions/VideoCopyToSeminar.vue
@@ -94,7 +94,7 @@ export default {
     methods: {
 
         getCourseLink(course) {
-            return window.STUDIP.URLHelper.getURL('plugins.php/opencast/course?cid=' + course.id)
+            return window.STUDIP.URLHelper.getURL('plugins.php/opencastv3/course?cid=' + course.id)
         },
 
         addCourseToList(course) {

--- a/vueapp/components/Videos/VideosSidebar.vue
+++ b/vueapp/components/Videos/VideosSidebar.vue
@@ -169,7 +169,7 @@ export default {
                     'upload.seriesId'  : this.currentUserSeries,
                     'upload.acl'       : false,
                     'upload.workflowId': this.getWorkflow(config_id),
-                    'return.target'    : window.STUDIP.URLHelper.getURL('plugins.php/opencast/contents/index#/contents/videos'),
+                    'return.target'    : window.STUDIP.URLHelper.getURL('plugins.php/opencastv3/contents/index#/contents/videos'),
                     'return.label'     : 'Stud.IP'
                 }
             );


### PR DESCRIPTION
The courseware block is still using the old api url to load the video. This leads to an error. These changes should solve such problems.