### PR TITLE
Sync the latest events first in cronjob

### DIFF
--- a/cronjobs/opencast_sync_acls.php
+++ b/cronjobs/opencast_sync_acls.php
@@ -59,7 +59,7 @@ class OpencastSyncAcls extends CronJob
             // call opencast to get all event ids
             $api_client = ApiEventsClient::getInstance($config['id']);
 
-            foreach ($api_client->getAll() as $event) {
+            foreach ($api_client->getAll(['sort' => 'date:DESC']) as $event) {
                 // only add videos / reinspect videos if they are readily processed
                 if ($event->status == 'EVENTS.EVENTS.STATUS.PROCESSED') {
                     // check if video exists in Stud.IP


### PR DESCRIPTION
It would probably be better to synchronise the ACLs of the latest videos first, since the old videos are rarely viewed. Especially in OC installations with several ten thousand videos, this could lead to delays until the ACLs of the recent videos are updated.