### PR TITLE
Fix courseware block

### DIFF
--- a/courseware/vueapp/components/CoursewareVideoTable.vue
+++ b/courseware/vueapp/components/CoursewareVideoTable.vue
@@ -65,10 +65,6 @@
                 </tbody>
             </table>
         </div>
-
-        <LtiAuth v-if="simple_config_list"
-            :simple_config_list="simple_config_list"
-        />
     </div>
 </template>
 

--- a/courseware/vueapp/courseware-plugin-opencast-video.vue
+++ b/courseware/vueapp/courseware-plugin-opencast-video.vue
@@ -25,6 +25,10 @@
                             Korrigieren sie die Sichtbarkeitseinstellungen im Opencast-Reiter.
                         </translate>
                     </div>
+
+                    <LtiAuth v-if="simple_config_list"
+                        :simple_config_list="simple_config_list"
+                    />
                 </div>
             </template>
             <template v-if="canEdit" #edit>
@@ -61,6 +65,7 @@
 const get = window._.get.bind(window._);
 import axios from 'axios';
 import { mapActions, mapGetters } from 'vuex';
+import LtiAuth from "./components/LtiAuth.vue";
 import CoursewareSearchBar from './components/CoursewareSearchBar.vue';
 import CoursewareVideoTable from './components/CoursewareVideoTable.vue';
 
@@ -68,6 +73,7 @@ export default {
     name: "courseware-plugin-opencast-video",
 
     components: {
+        LtiAuth,
         CoursewareSearchBar,
         CoursewareVideoTable,
     },


### PR DESCRIPTION
Changes:
- Load the LTI authentication in the block content instead of in the video table
- Show opencast connection error after lti check is performed

Fix #1049
Fix #1064