### PR TITLE
Skip unavailable events in playlist migration

### DIFF
--- a/lib/Helpers/PlaylistMigration.php
+++ b/lib/Helpers/PlaylistMigration.php
@@ -113,6 +113,8 @@ class PlaylistMigration
 
         $entries = [];
         foreach ($playlist_videos as $playlist_video) {
+            if (!$playlist_video['episode']) continue;
+
             $entries[] = [
                 'contentId' => $playlist_video['episode'],
                 'type' => 'EVENT'


### PR DESCRIPTION
I recieved an error when I tried to migrate the playlists in the opencast settings via the notification. This solved my problem.