### PR TITLE
Save correct service entry id in database

### DIFF
--- a/lib/Models/Playlists.php
+++ b/lib/Models/Playlists.php
@@ -619,13 +619,13 @@ class Playlists extends UPMap
                 $playlist_video = PlaylistVideos::create([
                     'video_id' => $db_video->id,
                     'playlist_id' => $this->id,
-                    'service_entry_id' => isset($entry->id) ?: null,
+                    'service_entry_id' => $entry->id ?? null,
                 ]);
             }
 
             if (!is_null($playlist_video)) {
                 // Always update entry id and order
-                $playlist_video->service_entry_id = isset($entry->id) ?: null;
+                $playlist_video->service_entry_id = $entry->id ?? null;
                 $playlist_video->order = $key;
                 $playlist_video->store();
             }


### PR DESCRIPTION
The boolean value of `isset($entry->id)` is stored in the database instead of the playlist entry id from opencast.