### PR TITLE
Fix missing course acls in studio upload

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,7 +20,7 @@ StudipAutoloader::addAutoloadPath(__DIR__, 'ElanEv');
 StudipAutoloader::addAutoloadPath(__DIR__ . '/lib', 'Opencast');
 
 // adding observer
+NotificationCenter::addObserver('Opencast\Models\Videos', 'addToCoursePlaylist', 'OpencastCourseSync');
 NotificationCenter::addObserver('Opencast\Models\Videos', 'parseEvent', 'OpencastVideoSync');
 NotificationCenter::addObserver('Opencast\Models\Videos', 'checkEventACL', 'OpencastVideoSync');
-NotificationCenter::addObserver('Opencast\Models\Videos', 'addToCoursePlaylist', 'OpencastVideoSync');
 NotificationCenter::addObserver('Opencast\Models\VideosUserPerms', 'setPermissions', 'OpencastVideoSync');

--- a/bootstrap_migrations.php
+++ b/bootstrap_migrations.php
@@ -11,7 +11,7 @@ StudipAutoloader::addAutoloadPath(__DIR__, 'ElanEv');
 StudipAutoloader::addAutoloadPath(__DIR__ . '/lib', 'Opencast');
 
 // adding observer
+NotificationCenter::addObserver('Opencast\Models\Videos', 'addToCoursePlaylist', 'OpencastCourseSync');
 NotificationCenter::addObserver('Opencast\Models\Videos', 'parseEvent', 'OpencastVideoSync');
 NotificationCenter::addObserver('Opencast\Models\Videos', 'checkEventACL', 'OpencastVideoSync');
-NotificationCenter::addObserver('Opencast\Models\Videos', 'addToCoursePlaylist', 'OpencastVideoSync');
 NotificationCenter::addObserver('Opencast\Models\VideosUserPerms', 'setPermissions', 'OpencastVideoSync');

--- a/cronjobs/opencast_worker.php
+++ b/cronjobs/opencast_worker.php
@@ -115,7 +115,8 @@ class OpencastWorker extends CronJob
                     // task is done, delete it
                     $task->delete();
 
-                    // send out Notification for video discovery plugins to react
+                    // send out Notifications for video discovery plugins to react
+                    NotificationCenter::postNotification('OpencastCourseSync', $event, $video);
                     NotificationCenter::postNotification('OpencastVideoSync', $event, $video);
                 } else {
                     // event is missing or has no publications.


### PR DESCRIPTION
In the worker cronjob, add the video to the playlist first, before the video acls are checked.

Fix #1059