### PR TITLE
Fix event acl cronjob

### DIFF
--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -757,12 +757,10 @@ class Videos extends UPMap
 
         // add course acls
         foreach ($this->playlists as $playlist) {
-            foreach ($playlist->courses->pluck('id') as $course_id) {
-                $courses[$course_id] = null;
-            }
+            $courses = array_merge($courses, $playlist->courses->pluck('id'));
         }
 
-        $courses = array_keys($courses);
+        $courses = array_unique($courses);
 
         $acl = array_merge($acl, Helpers::createACLsForCourses($courses));
 


### PR DESCRIPTION
- Remove duplicate course ids, if video is included in mutliple playlists of the same course
- Fix continuously increasing list of acls (e.g. course acls) by removing the unnecessary filter in addEpisodeAcl

adapted from #1044 