### PR TITLE
Allow opencast running on localhost

### DIFF
--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -232,7 +232,7 @@ class Config extends \SimpleOrMap
             }
 
             if ($comp) {
-                $services = RESTConfig::retrieveRESTservices($comp, $service_url['scheme']);
+                $services = RESTConfig::retrieveRESTservices($comp, $service_url);
 
                 if (empty($services)) {
                     Endpoints::removeEndpoint($this->id, 'services');

--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -31,13 +31,13 @@ class Helpers
        return $dates;
     }
 
-    static function retrieveRESTservices($components, $match_protocol)
+    static function retrieveRESTservices($components, $service_url)
     {
         $services = array();
         foreach ($components as $service) {
             if (!preg_match('/remote/', $service->type)
-                && !preg_match('#https?://localhost.*#', $service->host)
-                && mb_strpos($service->host, $match_protocol) === 0
+                && ($service_url['host'] == "localhost" || !preg_match('#https?://localhost.*#', $service->host))
+                && mb_strpos($service->host, $service_url['scheme']) === 0
             ) {
                 $services[preg_replace(array("/\/docs/"), array(''), $service->host.$service->path)]
                          = preg_replace("/\//", '', $service->path);

--- a/lib/Models/REST/Config.php
+++ b/lib/Models/REST/Config.php
@@ -53,14 +53,14 @@ class Config
         return false;
     }
 
-    public static function retrieveRESTservices($components, $match_protocol)
+    public static function retrieveRESTservices($components, $service_url)
     {
         $oc_services = self::SERVICES;
         $services   = [];
 
         foreach ($components as $service) {
-            if (!preg_match('#https?://localhost.*#', $service->host)
-                && mb_strpos($service->host, $match_protocol) === 0
+            if (($service_url['host'] == "localhost" || !preg_match('#https?://localhost.*#', $service->host))
+                && mb_strpos($service->host, $service_url['scheme']) === 0
             ) {
                 // check if service is wanted, active and online
                 if (isset($oc_services[$service->type])


### PR DESCRIPTION
I always have to remove the localhost check on my local development system. These changes allow opencast to run on localhost if the config service url points to localhost.

Also, it allows to run the OC container on localhost instead of 127.0.0.1 in the [tests workflow](https://github.com/elan-ev/studip-opencast-plugin/pull/1097).