### PR TITLE
Fix overlapping of playlist dialog by Stud.IP header

### DIFF
--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -58,7 +58,7 @@
                     </li>
                 </template>
                 <template v-else>
-                    <li v-if="canEdit" @click="showCreateDefaultPlaylist">
+                    <li v-if="canEdit" @click="showCreatePlaylist">
                         <studip-icon style="margin-top: -2px;" shape="add" role="clickable"/>
                         {{ $gettext('Kurswiedergabeliste hinzufügen') }}
                     </li>
@@ -206,7 +206,7 @@
                                 {{ $gettext('Studierendenupload verbieten') }}
                             </a>
                         </li>
-                        <li @click="showChangeDefaultPlaylist" v-if="canEdit" data-reject-toggle-sidebar="true">
+                        <li @click="$emit('changeDefaultPlaylist')" v-if="canEdit" data-reject-toggle-sidebar="true">
                             <studip-icon style="margin-left: -20px;" shape="refresh" role="clickable"/>
                             {{ $gettext('Standard-Kurswiedergabeliste ändern') }}
                         </li>
@@ -220,19 +220,6 @@
                 </ul>
             </div>
         </div>
-
-        <PlaylistAddCard v-if="addPlaylist"
-            :is-default="isDefault"
-            @done="closePlaylistAdd"
-            @cancel="closePlaylistAdd"
-        />
-
-        <PlaylistsLinkCard v-if="showChangeDefaultDialog"
-            :is-default="true"
-            :custom-title="$gettext('Kurswiedergabeliste wechseln')"
-            @done="closeChangeDefaultPlaylist"
-            @cancel="closeChangeDefaultPlaylist"
-        />
 
     </template>
 </template>
@@ -253,13 +240,20 @@ export default {
         PlaylistsLinkCard,
     },
 
-    emits: ['uploadVideo', 'recordVideo', 'copyAll', 'editPlaylist', 'sortVideo', 'saveSortVideo', 'cancelSortVideo'],
+    emits: [
+        'uploadVideo',
+        'recordVideo',
+        'copyAll',
+        'editPlaylist',
+        'sortVideo',
+        'saveSortVideo',
+        'cancelSortVideo',
+        'changeDefaultPlaylist'
+    ],
 
     data() {
         return {
             showAddDialog: false,
-            isDefault: false,
-            showChangeDefaultDialog: false,
             semesterFilter: null,
             schedulePlaylistToken: null,
             livestreamPlaylistToken: null,
@@ -269,11 +263,11 @@ export default {
     },
 
     computed: {
-        ...mapGetters(["playlists", "currentView", 'addPlaylist',
+        ...mapGetters(["playlists", "currentView", 'opencastOffline',
             "cid", "semester_list", "semester_filter", 'currentUser',
             'simple_config_list', 'course_config', 'playlist',
             'defaultPlaylist', 'videoSortMode', 'downloadSetting',
-            'schedule_playlist', 'livestream_playlist', 'opencastOffline'
+            'schedule_playlist', 'livestream_playlist'
         ]),
 
         fragment() {
@@ -404,24 +398,6 @@ export default {
 
         showCreatePlaylist() {
             this.$store.dispatch('addPlaylistUI', true);
-        },
-
-        showCreateDefaultPlaylist() {
-            this.isDefault = true;
-            this.$store.dispatch('addPlaylistUI', true);
-        },
-
-        showChangeDefaultPlaylist() {
-            this.showChangeDefaultDialog = true;
-        },
-
-        closeChangeDefaultPlaylist() {
-            this.showChangeDefaultDialog = false;
-        },
-
-        closePlaylistAdd() {
-            this.isDefault = false;
-            this.$store.dispatch('addPlaylistUI', false);
         },
 
         openPlaylistAddVideosDialog() {

--- a/vueapp/views/Course.vue
+++ b/vueapp/views/Course.vue
@@ -7,9 +7,16 @@
                 @saveSortVideo="saveSort"
                 @cancelSortVideo="cancelSort"
                 @editPlaylist="editPlaylistDialog = true"
+                @changeDefaultPlaylist="showChangeDefaultPlaylistDialog = true"
                 @copyAll="copyAll">
             </CoursesSidebar>
         </Teleport>
+
+        <PlaylistAddCard v-if="addPlaylist"
+            :is-default="!hasDefaultPlaylist"
+            @done="closePlaylistAddDialog"
+            @cancel="closePlaylistAddDialog"
+        />
 
         <PlaylistAddVideos v-if="showPlaylistAddVideosDialog"
             :canEdit="canEdit"
@@ -28,6 +35,13 @@
             @cancel="closeCopyDialog"
         />
 
+        <PlaylistsLinkCard v-if="showChangeDefaultPlaylistDialog"
+            :is-default="true"
+            :custom-title="$gettext('Kurswiedergabeliste wechseln')"
+            @done="showChangeDefaultPlaylistDialog = false"
+            @cancel="showChangeDefaultPlaylistDialog = false"
+        />
+
         <MessageList />
 
         <router-view></router-view>
@@ -39,6 +53,8 @@ import CoursesSidebar from "@/components/Courses/CoursesSidebar";
 import PlaylistAddVideos from "@/components/Playlists/PlaylistAddVideos";
 import VideoUpload from "@/components/Videos/VideoUpload";
 import MessageList from "@/components/MessageList";
+import PlaylistsLinkCard from '@/components/Playlists/PlaylistsLinkCard.vue';
+import PlaylistAddCard from '@/components/Playlists/PlaylistAddCard.vue';
 import PlaylistEditCard from '@/components/Playlists/PlaylistEditCard.vue';
 import VideoCopyToSeminar from '@/components/Videos/Actions/VideoCopyToSeminar.vue';
 
@@ -48,6 +64,7 @@ export default {
     name: "Course",
 
     components: {
+        PlaylistsLinkCard, PlaylistAddCard,
         PlaylistEditCard, CoursesSidebar,
         VideoUpload, PlaylistAddVideos,
         MessageList, VideoCopyToSeminar
@@ -58,6 +75,7 @@ export default {
             'currentUser',
             'showCourseCopyDialog',
             'showPlaylistAddVideosDialog',
+            'addPlaylist',
             'cid',
             'course_config'
         ]),
@@ -78,6 +96,10 @@ export default {
             return this.course_config.upload_allowed;
         },
 
+        hasDefaultPlaylist() {
+            return this.course_config?.has_default_playlist;
+        },
+
         toLayoutName() {
             if (window.OpencastPlugin.STUDIP_VERSION >= 5.3) {
                 return "#sidebar";
@@ -92,6 +114,7 @@ export default {
         return {
             uploadDialog: false,
             editPlaylistDialog: false,
+            showChangeDefaultPlaylistDialog: false,
         }
     },
 
@@ -114,6 +137,10 @@ export default {
 
         closePlaylistAddVideosDialog() {
             this.$store.dispatch('togglePlaylistAddVideosDialog', false);
+        },
+
+        closePlaylistAddDialog() {
+            this.$store.dispatch('addPlaylistUI', false);
         },
 
         closeCopyDialog() {


### PR DESCRIPTION
Some UI elements like the Stud.IP header or the table video actions are overlapping the playlist add dialog and the change course playlist dialog. This PR should fix this problem by changing the rendering location. The problem seems to be caused by the sticky position of the sidebar.

Screenshot
![image](https://github.com/user-attachments/assets/25cda111-6d6d-4d61-bd07-1ddb53774c85)