### PR TITLE
Fix series check during scheduling

### DIFF
--- a/lib/Models/SeminarSeries.php
+++ b/lib/Models/SeminarSeries.php
@@ -40,7 +40,7 @@ class SeminarSeries extends UPMap
             $series_client->setACL($series_id, $new_acl);
         }
 
-        return $series[$series_id];
+        return (bool) $series;
     }
 
     public static function getMissingSeries($course_id)


### PR DESCRIPTION
Fix series id is null error:

![Screenshot 2025-01-13 at 13-50-12 (!) Opencast Videos - Universität Osnabrück — Testsystem Opencast v3](https://github.com/user-attachments/assets/d710eef1-8634-4e77-8f34-e2bb2da00966)
