### PR TITLE
Fix broken playlist visibility

### DIFF
--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -38,7 +38,7 @@
                         }"
                         v-for="p in playlists"
                         v-bind:key="p.token"
-                        v-on:click="loadPlaylist(p)">
+                        v-on:click="setPlaylist(p)">
                         <router-link :to="{ name: 'course' }">
                             <div class="oc--playlist-title-contanier">
                                 <span class="oc--playlist-title">
@@ -362,8 +362,8 @@ export default {
     },
 
     methods: {
-        loadPlaylist(playlist) {
-            this.$store.dispatch('loadPlaylist', playlist.token);
+        setPlaylist(playlist) {
+            this.$store.dispatch('setPlaylist', playlist);
             this.toggleSidebarOnResponsive();
         },
 
@@ -444,7 +444,7 @@ export default {
                 let playlist_filtered = this.playlists.filter(playlist => playlist.token == this.targetPlaylistToken)
                 if (playlist_filtered?.length) {
                     await this.$nextTick();
-                    this.loadPlaylist(playlist_filtered[0]);
+                    this.setPlaylist(playlist_filtered[0]);
                     await this.$store.dispatch('loadPlaylists');
                     this.targetPlaylistToken = null;
                 }

--- a/vueapp/components/Playlists/PlaylistCard.vue
+++ b/vueapp/components/Playlists/PlaylistCard.vue
@@ -161,7 +161,7 @@ export default {
         },
 
         addToPlaylist(playlist) {
-            this.$store.dispatch('loadPlaylist', playlist.token);
+            this.$store.dispatch('setPlaylist', playlist);
             this.$store.dispatch('togglePlaylistAddVideosDialog', true);
         }
     }

--- a/vueapp/components/Playlists/PlaylistsCopyCard.vue
+++ b/vueapp/components/Playlists/PlaylistsCopyCard.vue
@@ -88,7 +88,7 @@ export default {
                     .then(() => {
                         if (is_default) {
                             // Set default playlist active
-                            this.$store.dispatch('loadPlaylist', this.defaultPlaylist.token);
+                            this.$store.dispatch('setPlaylist', this.defaultPlaylist);
                         }
                     });
 

--- a/vueapp/views/CoursesVideos.vue
+++ b/vueapp/views/CoursesVideos.vue
@@ -45,7 +45,7 @@ export default {
 
     mounted() {
         this.$store.dispatch('loadPlaylists').then(() => {
-            this.$store.dispatch('loadPlaylist', this.defaultPlaylist.token);
+            this.$store.dispatch('setPlaylist', this.defaultPlaylist);
         });
     },
 };


### PR DESCRIPTION
The synchronisation of the playlist with Opencast while loading the playlist implemented in #955 was removed in #1028. So the playlist doesn't need to be loaded separately from the backend. This fixes the bug that the visibility attribute is incompatible between course playlists `oc_playlist_seminar` and playlists `oc_playlist`. Now only course playlists should be used in a course.

This fixes the error that the playlist is empty for students after the action ‘Mediendownloads erlauben’ has been activated.