### PR TITLE
Don't rename playlist to "Kurswiedergabeliste" after update

### DIFF
--- a/lib/Routes/Course/CourseUpdatePlaylist.php
+++ b/lib/Routes/Course/CourseUpdatePlaylist.php
@@ -57,9 +57,6 @@ class CourseUpdatePlaylist extends OpencastController
         $playlist->store();
 
         $ret_playlist = $playlist_seminar->toSanitizedArray();
-        if ($playlist_seminar->is_default == '1') {
-            $ret_playlist['title'] = _('Kurswiedergabeliste');
-        }
 
         return $this->createResponse($ret_playlist, $response->withStatus(200));
     }


### PR DESCRIPTION
It looks like legacy code.