### PR TITLE
Fix node script build-dev

### DIFF
--- a/courseware/package.json
+++ b/courseware/package.json
@@ -21,9 +21,8 @@
         "lib": "lib/BlockTypes"
     },
     "scripts": {
-        "prebuild": "npm install",
-        "build": "webpack --mode production --config ./webpack-courseware.config.js",
-        "build-dev": "webpack --mode development --config ./webpack-courseware.config.js",
+        "build": "npm install && webpack --mode production --config ./webpack-courseware.config.js",
+        "build-dev": "npm install && webpack --mode development --config ./webpack-courseware.config.js",
         "devcw": "webpack --mode development --watch --config ./webpack-courseware.config.js",
         "dev": "webpack --mode development --watch --config ./webpack-courseware.config.js"
     },


### PR DESCRIPTION
The directory node_modules were missing in the courseware app. This has no effects to the production builds.