### PR TITLE
Show course videos in cw

### DIFF
--- a/assets/css/courseware.scss
+++ b/assets/css/courseware.scss
@@ -28,6 +28,26 @@
     white-space: nowrap;
 }
 
+.oc-cw-searchbar .oc-cw-searchbar-token {
+    margin: 3px;
+    padding: 5px;
+    border: solid thin $black;
+    background-color: $content-color-20;
+
+    display: inline;
+
+    span {
+        margin: 0 5px;
+        display: inline-block;
+        vertical-align: middle;
+    }
+
+    .oc-cw-remove-filter {
+        vertical-align: middle;
+        cursor: pointer;
+    }
+}
+
 .oc-cw-searchbar .oc-cw-searchbar-container .oc-cw-searchbar-input {
     padding: 8px;
     width: 100%;

--- a/assets/css/courseware.scss
+++ b/assets/css/courseware.scss
@@ -28,6 +28,37 @@
     white-space: nowrap;
 }
 
+.oc-cw-searchbar .oc-cw-tokenselector {
+    position: absolute;
+    z-index: 10;
+    border: thin solid $content-color-40;
+    background-color: $white;
+    margin-top: 12px;
+    min-width: 130px;
+
+    @include arrow-top-border(9px, white, 1px, $content-color-40, 12px);
+
+    &::before, &::after {
+        right: 90%;
+    }
+
+    ul, li {
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    li {
+        display: block;
+        padding: 0.5em;
+        cursor: pointer;
+
+        &:hover {
+            background-color: $light-gray-color-20;
+        }
+    }
+}
+
 .oc-cw-searchbar .oc-cw-searchbar-token {
     margin: 3px;
     padding: 5px;

--- a/courseware/vueapp/components/CoursewareSearchBar.vue
+++ b/courseware/vueapp/components/CoursewareSearchBar.vue
@@ -6,14 +6,19 @@
                 <studip-icon
                     shape="decline" role="clickable" class="oc-cw-remove-filter"
                     @click="removeCourse"
+                    @blur="delayedHideCourseSelector"
                 />
             </li>
             <li class="oc-cw-searchbar-input">
                 <input type="text"
                     ref="searchbar"
+                    v-on:keyup="hideCourseSelector"
                     v-on:keyup.enter="doSearch"
                     v-model="inputSearch"
                     :placeholder="$gettext('Suche...')"
+                    @focus="openCourseSelector"
+                    @click="openCourseSelector"
+                    @blur="delayedHideCourseSelector"
                     @input="doLiveSearch"
                 />
             </li>
@@ -26,6 +31,16 @@
                 />
             </li>
         </ul>
+
+        <div class="oc-cw-tokenselector" v-if="showCourseSelector"
+            :style="`left:` + selectorPos.left + `px; top:` + selectorPos.top + `px;`"
+        >
+            <ul>
+                <li @click="selectCourse">
+                    {{ $gettext('Diese Veranstaltung') }}
+                </li>
+            </ul>
+        </div>
     </div>
 </template>
 
@@ -34,6 +49,10 @@ export default {
     name: "CoursewareSearchBar",
 
     props: {
+        currentCourseSelectable: {
+            type: Boolean,
+            default: true,
+        },
         showCurrentCourse: {
             type: Boolean,
             default: true,
@@ -45,12 +64,41 @@ export default {
     data() {
         return {
             inputSearch: '',
+            showCourseSelector: false,
+            selectorPos: {
+                top: 0,
+                left: 0
+            },
             timer: null,
             delay: 800 //ms
         }
     },
 
     methods: {
+        openCourseSelector() {
+            // filter needs to be selectable and not active
+            if (this.currentCourseSelectable && !this.showCurrentCourse) {
+                this.showCourseSelector = true;
+
+                this.selectorPos.top = this.$refs.searchbar.offsetTop + 30;
+                this.selectorPos.left = this.$refs.searchbar.offsetLeft;
+            }
+        },
+
+        // this is done in order to avoid hiding (and therefore deactivating the token selector)
+        // before the click-events of the token selector had a chance to fire
+        delayedHideCourseSelector() {
+            let view = this;
+
+            window.setTimeout(() => {
+                view.hideCourseSelector();
+            }, 200);
+        },
+
+        hideCourseSelector() {
+            this.showCourseSelector = false;
+        },
+
         doSearch() {
             clearTimeout(this.timer);
 
@@ -68,9 +116,21 @@ export default {
             }, this.delay);
         },
 
+        selectCourse() {
+            this.showCurrentCourse = true;
+            this.hideCourseSelector();
+            this.doSearch();
+        },
+
         removeCourse() {
             this.showCurrentCourse = false;
             this.doSearch();
+        }
+    },
+
+    updated() {
+        if (this.showCourseSelector) {
+            this.openCourseSelector();
         }
     },
 }

--- a/courseware/vueapp/components/CoursewareSearchBar.vue
+++ b/courseware/vueapp/components/CoursewareSearchBar.vue
@@ -1,6 +1,13 @@
 <template>
     <div class="oc-cw-searchbar">
         <ul class="oc-cw-searchbar-container">
+            <li class="oc-cw-searchbar-token" v-show="showCurrentCourse">
+                <span>{{ $gettext('Diese Veranstaltung') }}</span>
+                <studip-icon
+                    shape="decline" role="clickable" class="oc-cw-remove-filter"
+                    @click="removeCourse"
+                />
+            </li>
             <li class="oc-cw-searchbar-input">
                 <input type="text"
                     ref="searchbar"
@@ -26,6 +33,15 @@
 export default {
     name: "CoursewareSearchBar",
 
+    props: {
+        showCurrentCourse: {
+            type: Boolean,
+            default: true,
+        },
+    },
+
+    emits: ['doSearch'],
+
     data() {
         return {
             inputSearch: '',
@@ -38,7 +54,10 @@ export default {
         doSearch() {
             clearTimeout(this.timer);
 
-            this.$emit('doSearch', this.inputSearch);
+            this.$emit('doSearch', {
+                searchText: this.inputSearch,
+                showCurrentCourse: this.showCurrentCourse,
+            });
         },
 
         doLiveSearch() {
@@ -47,6 +66,11 @@ export default {
             this.timer = setTimeout(() => {
                 this.doSearch();
             }, this.delay);
+        },
+
+        removeCourse() {
+            this.showCurrentCourse = false;
+            this.doSearch();
         }
     },
 }

--- a/courseware/vueapp/courseware-plugin-opencast-video.vue
+++ b/courseware/vueapp/courseware-plugin-opencast-video.vue
@@ -36,6 +36,7 @@
                         <translate>Videos</translate>
                     </label>
                     <CoursewareSearchBar
+                        :currentCourseSelectable="isCourse"
                         :showCurrentCourse="showCurrentCourse"
                         @doSearch="performSearch"
                     />

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -67,7 +67,7 @@ class Videos extends UPMap
             $stmt = \DBManager::get()->prepare($sql = 'SELECT oc_video.id FROM oc_video
                 JOIN oc_playlist_seminar ON (oc_playlist_seminar.seminar_id IN (:courses))
                 JOIN oc_playlist         ON (oc_playlist_seminar.playlist_id = oc_playlist.id)
-                JOIN oc_playlist_video   ON (oc_playlist.id = oc_playlist_video.playlist_id)
+                JOIN oc_playlist_video   ON (oc_playlist.id = oc_playlist_video.playlist_id AND oc_video.id = oc_playlist_video.video_id)
                 WHERE 1
             ');
 

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -60,7 +60,7 @@ class Videos extends UPMap
     {
         global $perm;
 
-        if ($perm->have_perm('admin', $user_id)) {
+        if ($perm->have_perm('tutor', $user_id)) {
             // get all courses and their playlists this user has access to. Only courses with activated OC plugin are included
             $courses = Helpers::getMyCourses($user_id);
 
@@ -190,8 +190,8 @@ class Videos extends UPMap
                 ':user_id'=> $user_id
             ];
 
-            if ($perm->have_perm('admin', $user_id)) {
-                $where = ' WHERE oc_video.id IN (:video_ids) ';
+            if ($perm->have_perm('tutor', $user_id)) {
+                $where = ' WHERE oc_video.id IN (:video_ids) OR p.user_id = :user_id';
                 $params[':video_ids'] = self::getFilteredVideoIDs($user_id);
             } else {
                 $sql  = ' INNER JOIN oc_video_user_perms AS p ON (p.user_id = :user_id AND p.video_id = oc_video.id) ';


### PR DESCRIPTION
Changes:
- In Courseware block, initially filter the videos of the course if a course exists
- In workplace, admins should see only the videos of their courses and videos with explicit permissions
    - Fixed Bug: Admins could see all videos of the system due to a missing video join
- In cw block and workplace, show tutors and lecturers their videos from their courses and videos with explicit permissions

Screenshot of cw block filter:
![image](https://github.com/user-attachments/assets/33407359-be53-486f-a1e8-79e986157b42)
