### PR TITLE
Allow deletion of faulty video entries in Stud.IP

### DIFF
--- a/cronjobs/opencast_clear_recycle_bin.php
+++ b/cronjobs/opencast_clear_recycle_bin.php
@@ -22,7 +22,12 @@ class OpencastClearRecycleBin extends CronJob
     {
         echo "Deletes all videos that have been marked as trash for at least " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL . " days\n";
 
-        $videos = Videos::findBySql("trashed=true AND state!='running' AND trashed_timestamp < NOW() - INTERVAL " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL ." DAY");
+        $videos = Videos::findBySql($q = "trashed = 1 AND (
+                state != 'running' OR
+                state IS NULL
+            ) AND trashed_timestamp
+                < NOW() - INTERVAL " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL ." DAY");
+
         foreach ($videos as $video) {
             echo "Video #" . $video->id . " (" . $video->title . ") ";
             if ($video->removeVideo()) {

--- a/lib/Models/REST/ApiEventsClient.php
+++ b/lib/Models/REST/ApiEventsClient.php
@@ -151,11 +151,6 @@ class ApiEventsClient extends RestClient
     {
         $response = $this->opencastApi->eventsApi->delete($episode_id);
 
-        // if the video does not exists (anymore) in opencast, it still shall be deleted in Stud.IP
-        if ($response['code'] == 404) {
-            return true;
-        }
-
         return $response['code'] < 400;
     }
 

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -700,10 +700,18 @@ class Videos extends UPMap
     public function removeVideo()
     {
         $api_event_client = ApiEventsClient::getInstance($this->config_id);
-        if ($api_event_client->deleteEpisode($this->episode)) {
-            return $this->delete();
+
+        // if the video exists in opencast, make sure it is deleted
+        if ($api_event_client->getEpisode($this->episode)) {
+            if ($api_event_client->deleteEpisode($this->episode)) {
+                return $this->delete();
+            } else {
+                return false;
+            }
         }
-        return false;
+
+        // if its not there anymore, just remove it from Stud.IP
+        return $this->delete();
     }
 
     /**


### PR DESCRIPTION
If the event in Opencast is not found, at least delete the entry in Stud.IP.

fixes #1139