### PR TITLE
Unify character sets and collations in migrations

### DIFF
--- a/migrations/001_init_ocplugin.php
+++ b/migrations/001_init_ocplugin.php
@@ -12,7 +12,7 @@ class InitOcplugin extends Migration {
               )  ROW_FORMAT=DYNAMIC;");
 
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_seminar_series` (
-                `seminar_id` VARCHAR( 32 ) NOT NULL ,
+                `seminar_id` VARCHAR( 32 ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
                 `series_id` VARCHAR( 64 ) NOT NULL ,
                 `visibility` ENUM(  'visible',  'invisible' )NOT NULL ,
                 `schedule` TINYINT( 1 ) NOT NULL DEFAULT '0',
@@ -20,7 +20,7 @@ class InitOcplugin extends Migration {
                 );");
 
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_resources` (
-                `resource_id` VARCHAR( 32 ) NOT NULL ,
+                `resource_id` VARCHAR( 32 ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
                 `capture_agent` VARCHAR( 64 ) NOT NULL ,
                 PRIMARY KEY (  `resource_id` ,  `capture_agent` )
                 );");
@@ -39,7 +39,7 @@ class InitOcplugin extends Migration {
         }
 
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_seminar_episodes` (
-                `seminar_id` VARCHAR( 32 ) NOT NULL ,
+                `seminar_id` VARCHAR( 32 ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
                 `episode_id` VARCHAR( 64 ) NOT NULL ,
                 `visible` ENUM( 'true', 'false' ) NOT NULL DEFAULT 'true',
                 PRIMARY KEY ( `seminar_id` , `episode_id` )
@@ -47,13 +47,13 @@ class InitOcplugin extends Migration {
 
 
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_scheduled_recordings` (
-                `seminar_id` VARCHAR( 32 ) NOT NULL ,
+                `seminar_id` VARCHAR( 32 ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
                 `series_id` VARCHAR( 64 ) NOT NULL ,
                 `date_id` VARCHAR( 32 ) NOT NULL ,
-                `resource_id` VARCHAR( 32 ) NOT NULL ,
+                `resource_id` VARCHAR( 32 ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
                 `capture_agent` VARCHAR( 64 ) NOT NULL ,
                 `event_id` VARCHAR( 64 ) NOT NULL,
-                `status` ENUM( 'scheduled', 'recorded' ) NOT NULL ,
+                `status` ENUM( 'scheduled', 'recorded' ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
                 PRIMARY KEY ( `seminar_id` , `series_id` , `date_id` , `resource_id` , `capture_agent` )
                 );");
 

--- a/migrations/002_workflow_storage.php
+++ b/migrations/002_workflow_storage.php
@@ -6,8 +6,8 @@ class WorkflowStorage extends Migration {
 
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_seminar_workflows` (
               `workflow_id` varchar(255) NOT NULL,
-              `seminar_id` varchar(32) NOT NULL,
-              `user_id` varchar(32) NOT NULL,
+              `seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+              `user_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
               PRIMARY KEY (`workflow_id`)
               ) ROW_FORMAT=DYNAMIC;");
     }

--- a/migrations/008_workflow_configuration.php
+++ b/migrations/008_workflow_configuration.php
@@ -4,9 +4,9 @@ class WorkflowConfiguration extends Migration {
     function up() {
 
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_seminar_workflow_configuration` (
-              `seminar_id` varchar(32) NOT NULL,
+              `seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
               `workflow_id` varchar(255) NOT NULL,
-              `target` ENUM('schedule', 'upload') NOT NULL DEFAULT 'schedule',
+              `target` ENUM('schedule', 'upload') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'schedule',
               `mkdate` INT DEFAULT 0,
               `chdate` INT DEFAULT 0,
               PRIMARY KEY (`seminar_id`, `target`)
@@ -16,7 +16,7 @@ class WorkflowConfiguration extends Migration {
                                     ADD COLUMN `workflow_id` VARCHAR(255) DEFAULT 'full',
                                     ADD COLUMN mktime INT DEFAULT 0,
                                     ADD COLUMN chdate INT DEFAULT 0,
-                                    CHANGE status status ENUM('scheduled','recorded','uploaded','processed') NOT NULL DEFAULT 'scheduled'
+                                    CHANGE status status ENUM('scheduled','recorded','uploaded','processed') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'scheduled'
                                     ;");
     }
 

--- a/migrations/022_add_tos.php
+++ b/migrations/022_add_tos.php
@@ -20,8 +20,8 @@ class AddTos extends Migration
         $db->exec("ALTER TABLE oc_config ADD tos TEXT NULL");
 
         $db->exec("CREATE TABLE IF NOT EXISTS `oc_tos` (
-            `seminar_id` varchar(32) NOT NULL,
-            `user_id` varchar(32) NOT NULL,
+            `seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+            `user_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
             PRIMARY KEY (`seminar_id`, `user_id`)
         )");
 

--- a/migrations/042_remove_oc_seminar_workflows.php
+++ b/migrations/042_remove_oc_seminar_workflows.php
@@ -11,8 +11,8 @@ class RemoveOcSeminarWorkflows extends Migration
         DBManager::get()->query("CREATE TABLE IF NOT EXISTS `oc_seminar_workflows` (
             `config_id` INT NOT NULL DEFAULT 1,
             `workflow_id` varchar(255) NOT NULL,
-            `seminar_id` varchar(32) NOT NULL,
-            `user_id` varchar(32) NOT NULL,
+            `seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+            `user_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
             `mkdate` INT DEFAULT 0,
             PRIMARY KEY (`workflow_id`)
             ) ROW_FORMAT=DYNAMIC;");

--- a/migrations/051_new_scheme_and_cronjobs.php
+++ b/migrations/051_new_scheme_and_cronjobs.php
@@ -37,12 +37,12 @@ class NewSchemeAndCronjobs extends Migration
 
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_playlist` (
             `id` int NOT NULL AUTO_INCREMENT,
-            `token` varchar(8),
+            `token` varchar(8) CHARACTER SET latin1 COLLATE latin1_bin UNIQUE,
             `title` varchar(255),
-            `visibility` enum('internal','free','public'),
+            `visibility` enum('internal','free','public') CHARACTER SET latin1 COLLATE latin1_bin,
             `chdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
             `mkdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-            `sort_order` varchar(30) NOT NULL DEFAULT 'created_desc',
+            `sort_order` varchar(30) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'created_desc',
             PRIMARY KEY (`id`),
             KEY `U.1` (`token`)
         );";
@@ -72,7 +72,7 @@ class NewSchemeAndCronjobs extends Migration
 
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_video` (
             `id` int NOT NULL AUTO_INCREMENT,
-            `token` varchar(12),
+            `token` varchar(12) CHARACTER SET latin1 COLLATE latin1_bin UNIQUE,
             `config_id` int,
             `episode` varchar(64) UNIQUE,
             `title` text,
@@ -81,7 +81,7 @@ class NewSchemeAndCronjobs extends Migration
             `views` int,
             `preview` text,
             `publication` text,
-            `visibility` enum('internal','free','public') NOT NULL DEFAULT 'internal',
+            `visibility` enum('internal','free','public') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT 'internal',
             `created` timestamp,
             `author` varchar(255),
             `contributors` varchar(1000),
@@ -97,7 +97,7 @@ class NewSchemeAndCronjobs extends Migration
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_video_sync` (
             `id` int NOT NULL AUTO_INCREMENT,
             `video_id` int,
-            `state` enum('running','scheduled','failed'),
+            `state` enum('running','scheduled','failed') CHARACTER SET latin1 COLLATE latin1_bin,
             `scheduled` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE CURRENT_TIMESTAMP,
             `trys` int,
             `chdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
@@ -123,7 +123,7 @@ class NewSchemeAndCronjobs extends Migration
 
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_tags` (
             `id` int NOT NULL AUTO_INCREMENT,
-            `user_id` VARCHAR(32) NOT NULL,
+            `user_id` VARCHAR(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
             `tag` varchar(255) NOT NULL,
             PRIMARY KEY (`id`),
             KEY `U.1` (`tag`, `user_id`)
@@ -154,8 +154,8 @@ class NewSchemeAndCronjobs extends Migration
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_playlist_seminar` (
             `id` int NOT NULL AUTO_INCREMENT,
             `playlist_id` int,
-            `seminar_id` varchar(32),
-            `visibility` enum('hidden','visible'),
+            `seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin,
+            `visibility` enum('hidden','visible') CHARACTER SET latin1 COLLATE latin1_bin,
             PRIMARY KEY (`id`),
             FOREIGN KEY (`playlist_id`) REFERENCES `oc_playlist`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
             KEY `U.1` (`playlist_id`, `seminar_id`)
@@ -166,7 +166,7 @@ class NewSchemeAndCronjobs extends Migration
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_playlist_seminar_video` (
             `playlist_seminar_id` int,
             `video_id` int,
-            `visibility` enum('hidden','visible'),
+            `visibility` enum('hidden','visible') CHARACTER SET latin1 COLLATE latin1_bin,
             PRIMARY KEY (`playlist_seminar_id`, `video_id`),
             FOREIGN KEY (`video_id`) REFERENCES `oc_video`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
             FOREIGN KEY (`playlist_seminar_id`) REFERENCES `oc_playlist_seminar`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
@@ -176,7 +176,7 @@ class NewSchemeAndCronjobs extends Migration
         // video directlu associated to a seminar - without playlist
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_video_seminar` (
             `video_id` int,
-            `seminar_id` varchar(32),
+            `seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin,
             `visibility` enum('hidden','visible'),
             PRIMARY KEY (`video_id`, `seminar_id`),
             FOREIGN KEY (`video_id`) REFERENCES `oc_video`(`id`)  ON DELETE CASCADE ON UPDATE CASCADE
@@ -192,8 +192,8 @@ class NewSchemeAndCronjobs extends Migration
 
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_video_user_perms` (
             `video_id` int,
-            `user_id` varchar(32),
-            `perm` enum('owner','write','read','share'),
+            `user_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+            `perm` enum('owner','write','read','share') CHARACTER SET latin1 COLLATE latin1_bin,
             PRIMARY KEY (`video_id`, `user_id`),
             FOREIGN KEY (`video_id`) REFERENCES `oc_video`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
           );
@@ -210,8 +210,8 @@ class NewSchemeAndCronjobs extends Migration
 
         $sql[] = "CREATE TABLE IF NOT EXISTS `oc_playlist_user_perms` (
             `playlist_id` int,
-            `user_id` varchar(32),
-            `perm` enum('owner','write','read','share'),
+            `user_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+            `perm` enum('owner','write','read','share') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
             PRIMARY KEY (`playlist_id`, `user_id`, `perm`),
             FOREIGN KEY (`playlist_id`) REFERENCES `oc_playlist`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
           );

--- a/migrations/053_new_courseware_block.php
+++ b/migrations/053_new_courseware_block.php
@@ -23,7 +23,7 @@ class NewCoursewareBlock extends Migration
             `id` int NOT NULL AUTO_INCREMENT,
             `token` varchar(32),
             `video_id` int,
-            `new_seminar_id` varchar(32),
+            `new_seminar_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin,
             PRIMARY KEY (`id`)
         );");
 

--- a/migrations/059_add_linkshare_table.php
+++ b/migrations/059_add_linkshare_table.php
@@ -13,7 +13,7 @@ class AddLinkshareTable extends Migration
         $db->exec("
             CREATE TABLE IF NOT EXISTS `oc_video_shares` (
                 `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
-                `token` varchar(32) NOT NULL,
+                `token` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
                 `video_id` int NOT NULL,
                 `password` varchar(255) NULL,
                 FOREIGN KEY (`video_id`) REFERENCES `oc_video` (`id`) ON DELETE CASCADE ON UPDATE CASCADE

--- a/migrations/061_update_workflow_tables.php
+++ b/migrations/061_update_workflow_tables.php
@@ -9,7 +9,7 @@ class UpdateWorkflowTables extends Migration
     public function up()
     {
         DBManager::get()->exec("ALTER TABLE `oc_workflow_config`
-            ADD `used_for` enum('schedule','upload','studio') NOT NULL AFTER `workflow`;
+            ADD `used_for` enum('schedule','upload','studio') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL AFTER `workflow`;
         ");
 
         DBManager::get()->exec("DROP TABLE `oc_workflow_config_scope`");

--- a/migrations/064_alter_linkshare_table.php
+++ b/migrations/064_alter_linkshare_table.php
@@ -11,7 +11,7 @@ class AlterLinkshareTable extends Migration
         $db = DBManager::get();
 
         $db->exec("ALTER TABLE `oc_video_shares`
-            CHANGE `password` `uuid` varchar(32) NULL,
+            CHANGE `password` `uuid` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NULL,
             MODIFY `token` varchar(16) NOT NULL,
             DROP PRIMARY KEY,
             DROP COLUMN `id`,

--- a/migrations/066_update_workflow_tables_two.php
+++ b/migrations/066_update_workflow_tables_two.php
@@ -27,7 +27,7 @@ class UpdateWorkflowTablesTwo extends Migration
         $db->exec("ALTER TABLE `oc_workflow_config`
             Drop COLUMN `displayname`,
             Drop COLUMN `workflow`,
-            MODIFY `used_for` enum('schedule','upload','studio','delete'),
+            MODIFY `used_for` enum('schedule','upload','studio','delete') CHARACTER SET latin1 COLLATE latin1_bin,
             ADD COLUMN workflow_id int,
             ADD UNIQUE KEY oc_workflow_config_unique(config_id, used_for),
             ADD CONSTRAINT oc_workflow_config_fk_wf_id FOREIGN KEY (`workflow_id`) REFERENCES `oc_workflow` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
@@ -69,7 +69,7 @@ class UpdateWorkflowTablesTwo extends Migration
         $db->exec("ALTER TABLE `oc_workflow_config`
             ADD COLUMN `displayname` varchar(255),
             ADD COLUMN `workflow` varchar(255),
-            MODIFY `used_for` enum('schedule','upload','studio'),
+            MODIFY `used_for` enum('schedule','upload','studio') CHARACTER SET latin1 COLLATE latin1_bin,
             DROP COLUMN workflow_id,
             DROP CONSTRAINT oc_workflow_config_unique;
         ");

--- a/migrations/072_add_user_series.php
+++ b/migrations/072_add_user_series.php
@@ -13,9 +13,9 @@ class AddUserSeries extends Migration
 
         $db->exec("CREATE TABLE IF NOT EXISTS `oc_user_series` (
             `config_id` INT NOT NULL DEFAULT 1,
-            `user_id` VARCHAR( 32 ) NOT NULL ,
+            `user_id` VARCHAR( 32 ) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
             `series_id` VARCHAR( 64 ) NOT NULL ,
-            `visibility` ENUM(  'visible',  'invisible' )NOT NULL ,
+            `visibility` ENUM('visible', 'invisible') CHARACTER SET latin1 COLLATE latin1_bin NOT NULL ,
             `chdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
             `mkdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
             PRIMARY KEY (`user_id` ,`series_id` ),

--- a/migrations/075_remove_editor_workflow_config.php
+++ b/migrations/075_remove_editor_workflow_config.php
@@ -12,7 +12,7 @@ class RemoveEditorWorkflowConfig extends Migration
         $db = DBManager::get();
 
         $db->exec("ALTER TABLE `oc_workflow_config`
-            MODIFY `used_for` enum('schedule','upload','studio','delete')
+            MODIFY `used_for` enum('schedule','upload','studio','delete') CHARACTER SET latin1 COLLATE latin1_bin
         ");
 
         SimpleOrMap::expireTableScheme();

--- a/migrations/077_update_cw_block.php
+++ b/migrations/077_update_cw_block.php
@@ -14,7 +14,7 @@ class UpdateCwBlock extends Migration
         $db->exec('START TRANSACTION');
 
         $db->exec('ALTER TABLE oc_video_cw_blocks
-            ADD `token` varchar(12) AFTER video_id');
+            ADD `token` varchar(12) CHARACTER SET latin1 COLLATE latin1_bin AFTER video_id');
 
 
         $stmt = $db->prepare('UPDATE oc_video_cw_blocks

--- a/migrations/093_add_subtitles_workflow.php
+++ b/migrations/093_add_subtitles_workflow.php
@@ -12,7 +12,7 @@ class AddSubtitlesWorkflow extends Migration
         $db = DBManager::get();
 
         $db->exec("ALTER TABLE `oc_workflow_config`
-            MODIFY `used_for` enum('schedule','upload','studio','delete','subtitles')
+            MODIFY `used_for` enum('schedule','upload','studio','delete','subtitles') CHARACTER SET latin1 COLLATE latin1_bin
         ");
 
         SimpleOrMap::expireTableScheme();


### PR DESCRIPTION
Sets the char set `latin1` and collation `latin1_bin`  in the migrations based on the [migration 90](https://github.com/elan-ev/studip-opencast-plugin/blob/1102d47eb95f20782222a9e28420f3c1d83a6e06/migrations/090_optimize_db.php).

Close #1143