### PR TITLE
Do not show missing default course playlist if the config is not available yet 

### DIFF
--- a/vueapp/views/CoursesVideos.vue
+++ b/vueapp/views/CoursesVideos.vue
@@ -39,6 +39,11 @@ export default {
         },
 
         hasDefaultPlaylist() {
+            // if the course config is not available, assume it has a default playlist
+            if (!this.course_config) {
+                return true;
+            }
+
             return this.course_config?.has_default_playlist;
         },
     },


### PR DESCRIPTION
fixes #1111 