### PR TITLE
Add server setting for role based event access

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,7 +72,27 @@ org.opencastproject.userdirectory.studip.cache.expiration=1
 
 Make sure to change the token and add that token to the Opencast config in Stud.IP. Furthermore configure the Opencast-Plugin in Stud.IP to have the `nobody` role for it to work.
 
-6. Add role `STUDIP` in Opencast
+6. Recommended for Opencast Version >= 17, edit `/etc/opencast/custom.properties` and enable: 
+
+```
+# Allow episode ID based access control via roles.
+# If activated, users with a role like ROLE_EPISODE_<ID>_<ACTION> will have access to the episode with the given
+# identifier, without this having to be explicitly stated in the ACL attached to the episode.
+#
+# For example, ROLE_EPISODE_872dc4ec-ca8a-4e12-8dac-ce99784d6d29_READ will allow the user to get read access to episode
+# 872dc4ec-ca8a-4e12-8dac-ce99784d6d29.
+#
+# To make this work for the Admin UI and External API, the Elasticsearch index needs to be updated with modified
+# ACLs. You can achieve this by calling the /index/rebuild/AssetManager/ACL endpoint AFTER activating this feature.
+# The endpoint will reindex only event ACLs.
+#
+# Default: false
+org.opencastproject.episode.id.role.access = true
+```
+
+This feature can then be activated in the plugin's Opencast settings (see below).
+
+7. Add role `STUDIP` in Opencast
 
 In the Opencast Admin UI, go to Organisation -> Groups and add a group named `STUDIP`.
 
@@ -118,6 +138,9 @@ The user needs to following role:
 Install the most recent version of this plugin, make sure that all migrations worked properly.
 
 After that go to "Admin" -> "System" -> "Opencast settings" and add a new server. Enter the URL and all the credentials for the Opencast system. Also make sure to assign to `nobody`-role to the plugin as well as entering the API-token for the user provider (see above).
+
+If you have Opencast Version 17 and the recommended feature enabled, you can enable the role based access via event id. This function removes the need for the plugin to set video ID roles on the videos, which reduces the number of roles on the videos and simplifies the migration to version 3. Without this function, the ACLs of all OC videos must be updated during migration.
+
 If everything worked you can now start using the plugin!
 
 Further help can be found under:

--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -219,16 +219,13 @@ class Config extends \SimpleOrMap
             } catch (AccessDeniedException $e) {
                 Endpoints::removeEndpoint($this->id, 'services');
 
-                $message = [
+                return [
                     'type' => 'error',
                     'text' => sprintf(
                         _('Fehlerhafte Zugangsdaten für die Opencast Installation mit der URL "%s". Überprüfen Sie bitte die eingegebenen Daten.'),
                         $service_host
                     )
                 ];
-
-                $this->redirect('admin/config');
-                return;
             }
 
             if ($comp) {

--- a/lib/Models/Config.php
+++ b/lib/Models/Config.php
@@ -13,7 +13,7 @@ class Config extends \SimpleOrMap
     use RelationshipTrait;
 
     protected const ALLOWED_SETTINGS_FIELDS = [
-        'lti_consumerkey', 'lti_consumersecret', 'debug', 'ssl_ignore_cert_errors'
+        'lti_consumerkey', 'lti_consumersecret', 'debug', 'ssl_ignore_cert_errors', 'episode_id_role_access'
     ];
 
     protected static function configure($config = [])

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -46,6 +46,11 @@ class Videos extends UPMap
             'thru_assoc_key' => 'playlist_id',
         ];
 
+        $config['belongs_to']['config'] = [
+            'class_name' => 'Opencast\Models\Config',
+            'foreign_key' => 'config_id',
+        ];
+
         parent::configure($config);
     }
 
@@ -758,26 +763,31 @@ class Videos extends UPMap
             return;
         }
 
-        // one ACL for reading AND for reading and writing
-        $acl = [
-            [
-                'allow'  => true,
-                'role'   => $this->episode .'_read',
-                'action' => 'read'
-            ],
+        $acl = [];
 
-            [
-                'allow'  => true,
-                'role'   => $this->episode .'_write',
-                'action' => 'read'
-            ],
+        // Don't set event id roles if episode id role access is activated by user
+        if (!$this->config->settings['episode_id_role_access'] ?? true) {
+            // one ACL for reading AND for reading and writing
+            $acl = [
+                [
+                    'allow'  => true,
+                    'role'   => $this->episode .'_read',
+                    'action' => 'read'
+                ],
 
-            [
-                'allow'  => true,
-                'role'   => $this->episode .'_write',
-                'action' => 'write'
-            ]
-        ];
+                [
+                    'allow'  => true,
+                    'role'   => $this->episode .'_write',
+                    'action' => 'read'
+                ],
+
+                [
+                    'allow'  => true,
+                    'role'   => $this->episode .'_write',
+                    'action' => 'write'
+                ]
+            ];
+        }
 
         $courses = [];
 

--- a/vueapp/components/Config/EditServer.vue
+++ b/vueapp/components/Config/EditServer.vue
@@ -151,6 +151,13 @@ export default {
                     required: false
                 },
                 {
+                    description: this.$gettext('Ist rollenbasierter Zugriff per Event-ID aktiviert?'),
+                    name: 'episode_id_role_access',
+                    value: this.currentConfig.episode_id_role_access ?? false,
+                    type: 'boolean',
+                    required: false
+                },
+                {
                     description: this.$gettext('Debugmodus einschalten?'),
                     name: 'debug',
                     value: this.currentConfig.debug,


### PR DESCRIPTION
Adds the "Ist rollenbasierter Zugriff per Event-ID aktiviert?" setting to disable the ACL check for event ID roles in the cronjob .

![image](https://github.com/user-attachments/assets/efe188fa-355d-4a59-b5f1-e328243cd76a)

Notes:
- No OC version check is added
- User provider still sets the old and the new roles as the requested config can not be loaded in the class.
- Video uploads will still set the old ACLs to avoid adding more complexity to the code.

Close #1150

Additionally, removes an incorrect redirect in config model.