### PR TITLE
Show no scheduled recordings in the videos table

### DIFF
--- a/cronjobs/opencast_discover_videos.php
+++ b/cronjobs/opencast_discover_videos.php
@@ -112,8 +112,8 @@ class OpencastDiscoverVideos extends CronJob
                             $task->store();
                         }
                     }
-                } else {
-                    // the event at least exists
+                } else if ($event->status != 'EVENTS.EVENTS.STATUS.SCHEDULED') {
+                    // the event at least exists and is not scheduled
                     $event_ids[] = $event->identifier;
                     $events[$event->identifier] = $event;
                 }


### PR DESCRIPTION
The "discover new videos" cronjob did not filter out scheduled recordings and added them to the worker queue.

Fix #1190