### PR TITLE
Only add owner video perm to uploader or scheduler of the recording

### DIFF
--- a/lib/Models/ScheduleHelper.php
+++ b/lib/Models/ScheduleHelper.php
@@ -435,6 +435,8 @@ class ScheduleHelper
      */
     private static function scheduleRecording($course_id, $resource_id, $date_id, $event_id, $livestream)
     {
+        global $user;
+
         $series = SeminarSeries::getSeries($course_id);
         $serie = $series[0];
 
@@ -457,6 +459,7 @@ class ScheduleHelper
         $success = ScheduledRecordings::setScheduleRecording(
             $course_id,
             $serie['series_id'],
+            $user->id,
             $date_id,
             $resource_id,
             $date->date,

--- a/lib/Models/ScheduledRecordings.php
+++ b/lib/Models/ScheduledRecordings.php
@@ -35,6 +35,7 @@ class ScheduledRecordings extends \SimpleORMap
     public static function setScheduleRecording(
         $seminar_id,
         $series_id,
+        $user_id,
         $date_id,
         $resource_id,
         $start,
@@ -54,6 +55,7 @@ class ScheduledRecordings extends \SimpleORMap
                 compact(
                     'seminar_id',
                     'series_id',
+                    'user_id',
                     'date_id',
                     'resource_id',
                     'start',

--- a/lib/Routes/Video/VideoAdd.php
+++ b/lib/Routes/Video/VideoAdd.php
@@ -67,11 +67,6 @@ class VideoAdd extends OpencastController
                 $oc_perm->store();
             }
 
-            // Assign permissions to teachers of the course, when it is a student upload in a course.
-            if (!empty($course_id) && $perm->have_studip_perm('user', $course_id, $user->id)) {
-                VideosUserPerms::assignCourseLecturerPermissions($course_id, $video->id);
-            }
-
             $ret = $video->toSanitizedArray();
 
             $message = [

--- a/migrations/102_add_user_to_scheduled_recordings.php
+++ b/migrations/102_add_user_to_scheduled_recordings.php
@@ -1,0 +1,24 @@
+<?php
+
+class AddUserToScheduledRecordings extends Migration
+{
+    public function description()
+    {
+        return 'Add user id to oc_scheduled_recordings to identify the user who scheduled the recording';
+    }
+
+    public function up()
+    {
+        $db = DBManager::get();
+
+        $db->exec('ALTER TABLE `oc_scheduled_recordings`
+            ADD COLUMN `user_id` varchar(32) CHARACTER SET latin1 COLLATE latin1_bin NULL AFTER `series_id`');
+    }
+
+    public function down()
+    {
+        $db = DBManager::get();
+
+        $db->exec('ALTER TABLE `oc_scheduled_recordings` DROP COLUMN `user_id`');
+    }
+}


### PR DESCRIPTION
Currently, all dozent get write perms to an uploaded course video or to a scheduled recording. This patch changes this behaviour based on #1216.

close #1216