### PR TITLE
Rework user videos

### DIFF
--- a/courseware/vueapp/courseware-plugin-opencast-video.vue
+++ b/courseware/vueapp/courseware-plugin-opencast-video.vue
@@ -270,7 +270,7 @@ export default {
                     params.append('filters', JSON.stringify(filters));
                 }
                 axios
-                    .get(STUDIP.ABSOLUTE_URI_STUDIP + 'plugins.php/opencastv3/api/videos', { params })
+                    .get(STUDIP.ABSOLUTE_URI_STUDIP + 'plugins.php/opencastv3/api/courseware/videos', { params })
                     .then(({ data }) => {
                         view.paging.items = parseInt(data.count);
                         view.paging.lastPage = parseInt(view.paging.items / view.limit);

--- a/lib/RouteMap.php
+++ b/lib/RouteMap.php
@@ -65,6 +65,9 @@ class RouteMap
         $group->put("/videos/{token}/shares", Routes\Video\VideoSharesUpdate::class);
         $group->post("/videos/{course_id}/copy", Routes\Video\VideoCopyToCourse::class);
 
+        // Courseware routes
+        $group->get("/courseware/videos", Routes\Courseware\CoursewareVideoList::class);
+
         // Playlist routes
         $group->get("/playlists", Routes\Playlist\PlaylistList::class);
         $group->post("/playlists", Routes\Playlist\PlaylistAdd::class);

--- a/lib/Routes/Courseware/CoursewareVideoList.php
+++ b/lib/Routes/Courseware/CoursewareVideoList.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Opencast\Routes\Courseware;
+
+use Opencast\Errors\AuthorizationFailedException;
+use Opencast\Models\Filter;
+use Opencast\Models\Videos;
+use Opencast\OpencastController;
+use Opencast\OpencastTrait;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class CoursewareVideoList extends OpencastController
+{
+    use OpencastTrait;
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        $params = $request->getQueryParams();
+
+        // select all videos the current user has perms on
+        $videos = Videos::getCoursewareVideos(new Filter($params));
+
+        $ret = [];
+        foreach ($videos['videos'] as $video) {
+            $video_array = $video->toSanitizedArray();
+            if (!empty($video_array['perm']) && ($video_array['perm'] == 'owner' || $video_array['perm'] == 'write'))
+            {
+                $video_array['perms'] = $video->perms->toSanitizedArray();
+            }
+            $ret[] = $video_array;
+        }
+
+        return $this->createResponse([
+            'videos' => $ret,
+            'count'  => $videos['count'],
+        ], $response);
+    }
+}

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -460,6 +460,9 @@ export default {
 
         doSearch(filters) {
             this.filters = filters;
+            if (this.$route.name === 'videosTrashed') {
+                this.filters.trashed = true;
+            }
             this.changePage(0);
             this.loadVideos();
         },

--- a/vueapp/store/videos.module.js
+++ b/vueapp/store/videos.module.js
@@ -109,7 +109,7 @@ const actions = {
             .then(({ data }) => {
                 commit('setVideos', data.videos);
 
-                if (data.count) {
+                if (data.count !== undefined) {
                     commit('setVideosCount', data.count);
                     commit('updatePaging', {
                         currPage: state.paging.currPage,


### PR DESCRIPTION
Changes:
-  Fix #1225
-  Fix #1219
- Replace some hardcoded course permission checks
- In work place, show only videos with explicit owner perm and no videos from course memberships, close #1219
- Fix incorrect perms in courseware of study groups
- In courseware, show all videos where the user has any explicit permission and all videos from courses with at least instructor perm