### PR TITLE
Fix re-inspection of videos without publications

### DIFF
--- a/cronjobs/opencast_worker.php
+++ b/cronjobs/opencast_worker.php
@@ -129,6 +129,7 @@ class OpencastWorker extends CronJob
                                     }
                                 } else {
                                     $video->state = 'failed';
+                                    $video->version   = $event->archive_version;
                                     $video->is_livestream = 0;
                                 }
                             }


### PR DESCRIPTION
Our test system re-schedules broken scheduled recordings in the cronjobs due to previous bugs, see #1208. These events are incorrectly marked as finished instead of scheduled in Opencast. The cronjob re-schedules them as the archive version will not be updated.