### PR TITLE
Show livestream bulk action only if schedule dates support livestream

### DIFF
--- a/lib/Models/ScheduleHelper.php
+++ b/lib/Models/ScheduleHelper.php
@@ -736,16 +736,18 @@ class ScheduleHelper
     }
 
     /**
-     * Gets the list of scheduling dates for a course to be displayed in the scheduling list in a course
+     * Gets the list of scheduling dates for a course to be displayed in the scheduling list in a course,
+     * and return a livestream flag indicating if livestream is available in some date
      *
      * @param string $course_id course id
      * @param string $semester_filter semester id
      *
-     * @return array the scheudling list to be displayed in a course
+     * @return array the scheduling list to be displayed in a course and the livestream available flag
      */
     public static function getScheduleList($course_id, $semester_filter)
     {
         $allow_schedule_alternate = \Config::get()->OPENCAST_ALLOW_ALTERNATE_SCHEDULE;
+        $livestream_available = false;
 
         $dates = self::getDatesForSemester($course_id, $semester_filter);
         $events = self::getCourseEvents($course_id);
@@ -851,6 +853,7 @@ class ScheduleHelper
             $actions = [];
             if (!empty($resource_obj)) {
                 $allow_livestream = !empty($resource_obj['livestream_workflow_id']) ? true : false;
+                $livestream_available |= $allow_livestream;
                 if ($scheduled && (int)date($d['date']) > time()) {
                     $actions['updateSchedule'] = [
                         'shape' => 'refresh',
@@ -889,7 +892,10 @@ class ScheduleHelper
             $schedule_list[] = $date_obj;
         }
 
-        return $schedule_list;
+        return [
+            'schedule_list' => $schedule_list,
+            'livestream_available' => $livestream_available,
+        ];
     }
 
     /**

--- a/lib/Routes/Course/CourseListSchedule.php
+++ b/lib/Routes/Course/CourseListSchedule.php
@@ -20,12 +20,13 @@ class CourseListSchedule extends OpencastController
         $semester_list = ScheduleHelper::getSemesterList($course_id);
         $allow_schedule_alternate = \Config::get()->OPENCAST_ALLOW_ALTERNATE_SCHEDULE;
 
-        $schedule_list = ScheduleHelper::getScheduleList($course_id, $semester_filter);
+        $schedules = ScheduleHelper::getScheduleList($course_id, $semester_filter);
 
         $response_data = [
             'semester_list' => $semester_list,
-            'schedule_list' => $schedule_list,
-            'allow_schedule_alternate' => $allow_schedule_alternate
+            'schedule_list' => $schedules['schedule_list'],
+            'livestream_available' => $schedules['livestream_available'],
+            'allow_schedule_alternate' => $allow_schedule_alternate,
         ];
 
         return $this->createResponse($response_data, $response);

--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -84,7 +84,7 @@
                 </select>
             </div>
         </div>
-        <div class="sidebar-widget " id="sidebar-actions" v-if="canSchedule">
+        <div class="sidebar-widget " id="sidebar-actions" v-if="canSchedule && (schedule_list.length || !schedule_loading)">
             <div class="sidebar-widget-header">
                 {{ $gettext('Aktionen') }}
             </div>
@@ -103,7 +103,7 @@
                         </option>
                     </select>
                 </div>
-                <div class="oc--sidebar-dropdown-wrapper">
+                <div class="oc--sidebar-dropdown-wrapper" v-if="this.livestream_available">
                     <span class="oc--sidebar-dropdown-text">
                         {{ $gettext('Livestreams in Wiedergabeliste') }}
                     </span>
@@ -267,7 +267,8 @@ export default {
             "cid", "semester_list", "semester_filter", 'currentUser',
             'simple_config_list', 'course_config', 'playlist',
             'defaultPlaylist', 'videoSortMode', 'downloadSetting',
-            'schedule_playlist', 'livestream_playlist'
+            'schedule_playlist', 'livestream_playlist', 'livestream_available',
+            'schedule_list', 'schedule_loading'
         ]),
 
         fragment() {

--- a/vueapp/components/Schedule/ScheduleList.vue
+++ b/vueapp/components/Schedule/ScheduleList.vue
@@ -132,15 +132,20 @@ export default {
     },
 
     computed: {
-        ...mapGetters(["schedule_list", "allow_schedule_alternate", "cid", 'schedule_loading']),
+        ...mapGetters(["schedule_list", "livestream_available", "allow_schedule_alternate", "cid", 'schedule_loading']),
 
         get_bulk_actions() {
-            let bulk_actions = [
-                {value: 'schedule', text: this.$gettext('Aufzeichnungen planen')},
-                {value: 'live', text: this.$gettext('LIVE-Aufzeichnungen planen')},
+            let bulk_actions = [];
+            bulk_actions.push({value: 'schedule', text: this.$gettext('Aufzeichnungen planen')});
+
+            if (this.livestream_available) {
+                bulk_actions.push({value: 'live', text: this.$gettext('LIVE-Aufzeichnungen planen')});
+            }
+
+            bulk_actions.push(
                 {value: 'update', text: this.$gettext('Aufzeichnungen aktualisieren')},
-                {value: 'unschedule', text: this.$gettext('Aufzeichnungen stornieren')},
-            ];
+                {value: 'unschedule', text: this.$gettext('Aufzeichnungen stornieren')}
+            );
 
             return bulk_actions;
         }

--- a/vueapp/store/schedule.module.js
+++ b/vueapp/store/schedule.module.js
@@ -4,6 +4,7 @@ const state = {
     schedule_list: [],
     semester_list: [],
     semester_filter: 'all',
+    livestream_available: false,
     allow_schedule_alternate: false,
     schedule_loading: false
 }
@@ -15,6 +16,10 @@ const getters = {
 
     semester_list(state) {
         return state.semester_list;
+    },
+
+    livestream_available(state) {
+        return state.livestream_available;
     },
 
     allow_schedule_alternate(state) {
@@ -47,6 +52,9 @@ const actions = {
                 }
                 if (data?.schedule_list) {
                     context.commit('setScheduleList', data.schedule_list);
+                }
+                if (data?.livestream_available) {
+                    context.commit('setLivestreamAvailable', data.livestream_available);
                 }
                 if (data?.allow_schedule_alternate) {
                     context.commit('setAllowAlternate', data.allow_schedule_alternate);
@@ -150,6 +158,10 @@ const mutations = {
 
     setSemesterList(state, list) {
         state.semester_list = list;
+    },
+
+    setLivestreamAvailable(state, available) {
+        state.livestream_available = available;
     },
 
     setAllowAlternate(state, allow) {


### PR DESCRIPTION
Change:
- Show bulk action "Live-Aufzeichnungen planen" only if some of the resources in the listed schedule dates allow live stream.
- Show target playlist selector action if the above condition is met.

Close #1160