### PR TITLE
Show scheduled recordings nav item if no playlist is available

### DIFF
--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -278,8 +278,7 @@ export default {
             try {
                 return this.cid !== undefined &&
                     this.currentUser.can_edit &&
-                        this.simple_config_list['settings']['OPENCAST_ALLOW_SCHEDULER'] &&
-                        this.hasDefaultPlaylist;
+                        this.simple_config_list['settings']['OPENCAST_ALLOW_SCHEDULER'];
             } catch (error) {
                 return false;
             }


### PR DESCRIPTION
If no (default) playlist is available, a new default playlist will be created for finished recordings.

![image](https://github.com/user-attachments/assets/407091d7-4b5e-44d1-a765-0566212e7a0a)

Fix #1158