### PR TITLE
Fix periodic execution times of cronjobs

### DIFF
--- a/migrations/051_new_scheme_and_cronjobs.php
+++ b/migrations/051_new_scheme_and_cronjobs.php
@@ -296,9 +296,9 @@ class NewSchemeAndCronjobs extends Migration
         // add new scheduling cronjob
         $task_id = $scheduler->registerTask(self::FILENAME, true);
 
-        // Schedule job to run every 360 minutes
+        // Schedule job to run every 2 hours
         if ($task_id) {
-            $scheduler->schedulePeriodic($task_id, -120);  // negative value means "every x minutes"
+            $scheduler->schedulePeriodic($task_id, 0, -2);  // negative value means "every x hours"
         }
     }
 

--- a/migrations/094_add_acl_cronjob.php
+++ b/migrations/094_add_acl_cronjob.php
@@ -15,9 +15,9 @@ class AddAclCronjob extends Migration
         // add new scheduling cronjob
         $task_id = $scheduler->registerTask(self::FILENAME, true);
 
-        // Schedule job to run every 120 minutes
+        // Schedule job to run every 2 hours
         if ($task_id) {
-            $scheduler->schedulePeriodic($task_id, -120);  // negative value means "every x minutes"
+            $scheduler->schedulePeriodic($task_id, 0, -2);  // negative value means "every x hours"
         }
     }
 


### PR DESCRIPTION
The execution of cronjobs every 120 minutes does not work. This patch changes the period to every 2 hours.

Fix #1238