### PR TITLE
Add owner column if explicit permission assigning is disabled

### DIFF
--- a/assets/css/opencast.scss
+++ b/assets/css/opencast.scss
@@ -312,7 +312,8 @@ $action-menu-icon-size: 20px;
                 gap: 5px;
 
                 margin: 0;
-                overflow-wrap: anywhere;
+                hyphens: auto;
+                overflow-wrap: break-word;
             }
 
             a {
@@ -325,21 +326,8 @@ $action-menu-icon-size: 20px;
                 row-gap: 5px;
 
                 margin-top: 8px;
-                white-space: nowrap;
                 overflow: auto;
             }
-        }
-
-        .oc--date {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        .oc--presenters {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
         }
 
         .oc--metadata--empty {
@@ -353,15 +341,10 @@ $action-menu-icon-size: 20px;
             .tooltip {
                 margin: 5px 0 0 5px;
             }
-        }
-    }
 
-    .oc--sort-options {
-        text-align: right;
-        white-space: nowrap;
-
-        img {
-            cursor: pointer;
+            .oc--tooltip-access.responsive-show {
+                display: none;
+            }
         }
     }
 
@@ -1022,6 +1005,18 @@ label.oc--file-upload {
     @extend .oc--pagination;
     visibility: hidden;
     display: none;
+}
+
+@media only screen and (max-width: $major-breakpoint-medium) {
+    .oc--episode-table--small {
+        .oc--episode {
+            .oc--tooltips {
+                .oc--tooltip-access.responsive-show {
+                    display: unset;
+                }
+            }
+        }
+    }
 }
 
 @media only screen and (max-width: $major-breakpoint-small) {

--- a/migrations/102_config_option_permission_assignment.php
+++ b/migrations/102_config_option_permission_assignment.php
@@ -1,0 +1,36 @@
+<?php
+class ConfigOptionPermissionAssignment extends Migration
+{
+
+
+    public function description()
+    {
+        return 'Add config option to allow permission assignment';
+    }
+
+    public function up()
+    {
+        $db = DBManager::get();
+
+        // Add global config to allow permission assignment
+        $stmt = $db->prepare('REPLACE INTO config (field, value, section, type, `range`, mkdate, chdate, description)
+            VALUES (:name, :value, :section, :type, :range, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), :description)');
+
+        $stmt->execute([
+            'name'        => 'OPENCAST_ALLOW_PERMISSION_ASSIGNMENT',
+            'section'     => 'opencast',
+            'description' => 'Sollen Nutzende Rechte an Videos vergeben können?',
+            'range'       => 'global',
+            'type'        => 'boolean',
+            'value'       => true
+        ]);
+    }
+
+    public function down()
+    {
+        $db = DBManager::get();
+
+        DBManager::get()->exec("DELETE FROM config WHERE field = 'OPENCAST_ALLOW_PERMISSION_ASSIGNMENT'");
+        DBManager::get()->exec("DELETE FROM config_values WHERE field = 'OPENCAST_ALLOW_PERMISSION_ASSIGNMENT'");
+    }
+}

--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -125,6 +125,10 @@
             {{ event.presenters ?? '' }}
         </td>
 
+        <td v-if="showOwnerColumn" class="responsive-hidden">
+            {{ getOwners ?? '' }}
+        </td>
+
         <td class="oc--tooltips">
             <div data-tooltip class="tooltip" v-if="getInfoText">
                 <span class="tooltip-content" v-html="getInfoText"></span>
@@ -142,7 +146,9 @@
                 />
             </div>
 
-            <div data-tooltip class="tooltip" v-if="getAccessText && canEdit">
+            <div data-tooltip class="tooltip oc--tooltip-access" :class="{ 'responsive-show': showOwnerColumn }"
+                v-if="getAccessText && canEdit"
+            >
                 <span class="tooltip-content" v-html="getAccessText"></span>
                 <studip-icon
                     shape="group2"
@@ -201,6 +207,10 @@ export default {
             default: false
         },
         selectable: {
+            type: Boolean,
+            default: false
+        },
+        showOwnerColumn: {
             type: Boolean,
             default: false
         },
@@ -405,6 +415,10 @@ export default {
 
         isChecked() {
             return this.selectedVideos.indexOf(this.event.token) >= 0;
+        },
+
+        getOwners() {
+            return this.event.perms?.flatMap(perm => perm.perm === 'owner' ? [perm.fullname] : []).join(', ');
         },
 
         getAccessText() {

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -26,6 +26,7 @@
                 <col>
                 <col style="width: 180px" class="responsive-hidden">
                 <col style="width: 150px" class="responsive-hidden">
+                <col v-if="showOwnerColumn" style="width: 150px" class="responsive-hidden">
                 <col style="width: 18px">
                 <col v-if="showActions && !videoSortMode" style="width: 64px">
             </colgroup>
@@ -54,6 +55,9 @@
                         <a href="#" @click.prevent>
                             {{ $gettext('Vortragende(r)') }}
                         </a>
+                    </th>
+                    <th v-if="showOwnerColumn"  data-sort="false" class="responsive-hidden">
+                        {{ $gettext('Besitzer/-in') }}
                     </th>
                     <th></th>
                     <th v-if="showActions && !videoSortMode" class="actions" data-sort="false">{{ $gettext('Aktionen') }}</th>
@@ -88,6 +92,7 @@
                         :selectedVideos="selectedVideos"
                         @toggle="toggleVideo"
                         :selectable="selectable"
+                        :showOwnerColumn="showOwnerColumn"
                         :isCourse="isCourse"
                         :canUpload="canUpload"
                         :showActions="showActions"
@@ -305,11 +310,23 @@ export default {
         ]),
 
         numberOfColumns() {
-          return 7 - (this.showCheckbox ? 0 : 1) - (this.showActions ? 0 : 1);
+          return 5 + (this.showCheckbox ? 1 : 0) + (this.showActions ? 1 : 0) + (this.showOwnerColumn ? 1 : 0);
         },
 
         showCheckbox() {
             return this.selectable || this.canEdit || this.canUpload;
+        },
+
+        showOwnerColumn() {
+            if (this.simple_config_list?.settings === undefined || this.simple_config_list.settings.OPENCAST_ALLOW_PERMISSION_ASSIGNMENT) {
+                return false;
+            }
+
+            if (this.isCourse && this.playlist) {
+                return this.canEdit;
+            }
+
+            return true;
         },
 
         isCourse() {


### PR DESCRIPTION
Draft:
- This changes must be tested first

Notes:
- No owner column has been added to the cw block
- The column is visisible if config `OPENCAST_ALLOW_PERMISSION_ASSIGNMENT` is true
- Column is shown in the course, in the work place and in dialogs
- Students can not see the column in a course
- Allow line breaks in the video table cells for improved responsiveness

Screenshots:
![image](https://github.com/user-attachments/assets/6227c35b-734c-41b9-ba55-0273a36a8a8b)


This PR bases on #1233