### PR TITLE
Add missing playlist migration check

### DIFF
--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -3,6 +3,7 @@
 namespace Opencast\Models;
 
 use Opencast\Errors\Error;
+use Opencast\Helpers\PlaylistMigration;
 use Opencast\Models\Tags;
 use Opencast\Models\Playlists;
 use Opencast\Models\REST\ApiEventsClient;
@@ -1189,7 +1190,9 @@ class Videos extends UPMap
                     $pvideo->store();
 
                     // update playlist in opencast as well
-                    $playlist->addEntries([$video]);
+                    if (PlaylistMigration::isConverted()) {
+                        $playlist->addEntries([$video]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If no playlists are migrated to Opencast, the cronjob `opencast_worker` tries to create the playlist in Opencast.

Stack trace:
```
PHP Fatal error: Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, null given in /data/studip/os-5.5/public/plugins_packages/elan-ev/OpencastV3/lib/Models/Playlists.php:609
Stack trace:
#0 /data/studip/os-5.5/public/plugins_packages/elan-ev/OpencastV3/lib/Models/Playlists.php(609): array_filter(NULL, Object(Closure))
#1 /data/studip/os-5.5/public/plugins_packages/elan-ev/OpencastV3/lib/Models/Videos.php(1192): Opencast\Models\Playlists->addEntries(Array)
#2 /data/studip/os-5.5/lib/classes/NotificationCenter.class.php(130): Opencast\Models\Videos::addToCoursePlaylist('OpencastCourseS...', Object(stdClass), Object(Opencast\Models\Videos))
#3 /data/studip/os-5.5/public/plugins_packages/elan-ev/OpencastV3/cronjobs/opencast_worker.php(174): NotificationCenter::postNotification('OpencastCourseS...', Object(stdClass), Object(Opencast\Models\Videos))
#4 /data/studip/os-5.5/lib/models/CronjobTask.class.php(151): OpencastWorker->execute(NULL, Array)
#5 /data/studip/os-5.5/lib/models/CronjobSchedule.class.php(222): CronjobTask->engage(NULL, Array)
#6 /data/studip/os-5.5/lib/classes/CronjobScheduler.class.php(287): CronjobSchedule->execute()
#7 /data/studip/os-5.5/cli/Commands/Cronjobs/CronjobWorker.php(21): CronjobScheduler->run()
#8 /data/studip/os-5.5/composer/symfony/console/Command/Command.php(298): Studip\Cli\Commands\Cronjobs\CronjobWorker->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /data/studip/os-5.5/composer/symfony/console/Application.php(1040): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /data/studip/os-5.5/composer/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(Studip\Cli\Commands\Cronjobs\CronjobWorker), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /data/studip/os-5.5/composer/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /data/studip/os-5.5/cli/studip(69): Symfony\Component\Console\Application->run()
#13 {main}
```