### PR TITLE
Show clickable video title if no preview is available

### DIFF
--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -100,7 +100,7 @@
                    href="#" @click.prevent="redirectAction(`/livestream/` + event.token)" target="_blank">
                     {{event.title}}
                 </a>
-                <a v-else-if="event.publication && event.preview && event.available"
+                <a v-else-if="event.publication && event.available"
                    href="#" @click.prevent="redirectAction(`/video/` + event.token)" target="_blank">
                     {{event.title}}
                 </a>


### PR DESCRIPTION
Our Opencast system provides no previews on some videos. Therefore, the video title should be clickable on these videos too. The video container is clickable due to https://github.com/elan-ev/studip-opencast-plugin/commit/6505a9956cc78756fdbbf4b2b62051e379a39d36.