### PR TITLE
Hide videos not available in OC but don't delete them from Stud.IP DB

### DIFF
--- a/cronjobs/opencast_discover_videos.php
+++ b/cronjobs/opencast_discover_videos.php
@@ -176,13 +176,13 @@ class OpencastDiscoverVideos extends CronJob
                 }
             } while (sizeof($oc_events) > 0);
 
-            // Check if local videos are not longer available in OC and remove them from Stud.IP
-            // If the video should reappear in the future, Stud.IP will readd it again.
+            // Check if local videos are no longer available in OC
             foreach (array_diff($local_event_ids, $event_ids) as $event_id) {
                 $video = Videos::findOneBySql("config_id = ? AND episode = ?", [$config['id'], $event_id]);
                 // Need null check for archived videos
                 if ($video) {
-                    $video->delete();
+                    $video->setValue('available', false);
+                    $video->store();
                 }
             }
 

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -424,6 +424,9 @@ class Videos extends UPMap
         $where .= " AND trashed = " . $filters->getTrashed();
         $where .= " AND oc_video.token IS NOT NULL";
 
+        // Show only videos available in opencast to users
+        $where .= " AND oc_video.available = 1";
+
         $sql .= $where;
 
         $sql .= ' GROUP BY oc_video.id';


### PR DESCRIPTION
We don't like the idea of simply deleting videos that are not available in OC from Stud.IP, because problems in the OC search index would trigger this deletion. Instead, these videos will be hidden.