### PR TITLE
Refactor preview handling in Videos model and VideoRow component to bring Editor back

### DIFF
--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -534,7 +534,8 @@ class Videos extends UPMap
         $data['mkdate'] = ($data['mkdate'] == '0000-00-00 00:00:00')
             ? 0 : \strtotime($data['mkdate']);
 
-        $data['preview']     = json_decode($data['preview'], true);
+        // Based on the change to the preview structure, we are not dealing with preview object (json encoded) here anymore, but an URL in string format.
+        $data['preview']     = $data['preview'] ?: null;
         $data['publication'] = json_decode($data['publication'], true);
 
         $data['perm']                 = $this->getUserPerm();

--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -515,7 +515,8 @@ export default {
                         });
                     }
 
-                    if ((this.event?.preview?.has_previews || this.event?.state == 'cutting') && !this.isLivestream) {
+                    // As we abandoned the preview object structure, we now have to only validate the preview URL!
+                    if ((this.event?.preview || this.event?.state == 'cutting') && !this.isLivestream) {
                         menuItems.push({
                             id: 5,
                             label: this.$gettext('Videoeditor öffnen'),


### PR DESCRIPTION
This PR fixes #1306.

It contains the change of dealing with video preview in the `Videos::toSanitizedArray` from json encoded to a simple string URL, Also includes the validation in VideoRow component to only look for `preview` and gets rid of `has_preview`.