### PR TITLE
Course Default Visibility feature

### DIFF
--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -109,7 +109,7 @@ class Videos extends UPMap
             $sql .= ' INNER JOIN oc_playlist_seminar AS ops ON (ops.seminar_id = :cid AND ops.playlist_id = opv.playlist_id)'.
                     ' LEFT JOIN oc_playlist_seminar_video AS opsv ON (opsv.playlist_seminar_id = ops.id AND opsv.video_id = opv.video_id)';
 
-            $where = ' WHERE '. self::getVisibilitySql();
+            $where = ' WHERE '. self::getVisibilitySql($cid);
 
             $params[':cid'] = $cid;
         }
@@ -150,7 +150,7 @@ class Videos extends UPMap
         if (!$perm->have_studip_perm($required_course_perm, $course_id)) {
             $sql .= ' LEFT JOIN oc_playlist_seminar_video AS opsv ON (opsv.playlist_seminar_id = ops.id AND opsv.video_id = opv.video_id)';
 
-            $where = ' WHERE '. self::getVisibilitySql();
+            $where = ' WHERE '. self::getVisibilitySql($course_id);
         }
 
         $query = [
@@ -162,10 +162,15 @@ class Videos extends UPMap
         return self::getFilteredVideos($query, $filters);
     }
 
-    private static function getVisibilitySql()
+    private static function getVisibilitySql($course_id)
     {
         // if each video has to explicitly set to visible, filter out everything else
-        if (\Config::get()->OPENCAST_HIDE_EPISODES) {
+        $course_hide_episodes = \Config::get()->OPENCAST_HIDE_EPISODES;
+        $course_default_episodes_visibility = \CourseConfig::get($course_id)->OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY ?? 'default';
+        if ($course_default_episodes_visibility !== 'default') {
+            $course_hide_episodes = $course_default_episodes_visibility === 'hidden' ? true : false;
+        }
+        if ($course_hide_episodes) {
             return '(
                 (opsv.visibility = "visible" AND opsv.visible_timestamp IS NULL)
                 OR (opsv.visible_timestamp < NOW())
@@ -494,7 +499,7 @@ class Videos extends UPMap
         if (!$perm->have_perm('dozent', $user_id)) {
             $sql .= ' LEFT JOIN oc_playlist_seminar_video AS opsv ON (opsv.playlist_seminar_id = ops.id AND opsv.video_id = opv.video_id)';
 
-            $where .= ' AND '. self::getVisibilitySql();
+            $where .= ' AND '. self::getVisibilitySql($course_id);
         }
 
         $sql .= $where;

--- a/lib/RouteMap.php
+++ b/lib/RouteMap.php
@@ -108,6 +108,8 @@ class RouteMap
         $group->delete("/courses/{course_id}/playlist/{token}", Routes\Course\CourseRemovePlaylist::class);
 
         $group->put("/courses/{course_id}/upload/{upload}", Routes\Course\CourseSetUpload::class); // TODO: document in api docs
+        // TODO: document in api docs?
+        $group->put("/courses/{course_id}/episodes_visibility", Routes\Course\CourseSetDefaultVideosVisibility::class);
 
         $group->get("/courses/videos", Routes\Course\CourseListForUserVideos::class);
         $group->get("/courses/videos/playlist/{token}", Routes\Course\CourseListForPlaylistVideos::class);

--- a/lib/Routes/Course/CourseConfig.php
+++ b/lib/Routes/Course/CourseConfig.php
@@ -53,16 +53,31 @@ class CourseConfig extends OpencastController
             }
         }
 
+        // Default Course Episodes Visibility.
+        // The course specific config option OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY has 3 possible values:
+            // - default: use the default value from the config (OPENCAST_HIDE_EPISODES) at the time!
+            // - visible: show the episodes to students by default
+            // - hidden: hide the episodes from students by default
+        // Getting with the default value from the config (OPENCAST_HIDE_EPISODES).
+        $course_hide_episodes = \Config::get()->OPENCAST_HIDE_EPISODES;
+        $course_default_episodes_visibility = \CourseConfig::get($course_id)->OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY
+                                                ?? 'default';
+        if ($course_default_episodes_visibility !== 'default') {
+            $course_hide_episodes = $course_default_episodes_visibility === 'hidden' ? true : false;
+        }
+
         $results = [
             'series'    => [
                 'series_id'  => $series->series_id,
             ],
-            'workflow'              => SeminarWorkflowConfiguration::getWorkflowForCourse($course_id),
-            'edit_allowed'          => Perm::editAllowed($course_id),
-            'upload_allowed'        => Perm::uploadAllowed($course_id),
-            'upload_enabled'        => \CourseConfig::get($course_id)->OPENCAST_ALLOW_STUDENT_UPLOAD ? 1 : 0,
-            'has_default_playlist'  => Helpers::checkCourseDefaultPlaylist($course_id),
-            'scheduling_allowed'    => Perm::schedulingAllowed($course_id)
+            'workflow'                           => SeminarWorkflowConfiguration::getWorkflowForCourse($course_id),
+            'edit_allowed'                       => Perm::editAllowed($course_id),
+            'upload_allowed'                     => Perm::uploadAllowed($course_id),
+            'upload_enabled'                     => \CourseConfig::get($course_id)->OPENCAST_ALLOW_STUDENT_UPLOAD ? 1 : 0,
+            'has_default_playlist'               => Helpers::checkCourseDefaultPlaylist($course_id),
+            'scheduling_allowed'                 => Perm::schedulingAllowed($course_id),
+            'course_hide_episodes'               => $course_hide_episodes, // Use this in a course instead of OPENCAST_HIDE_EPISODES!
+            'course_default_episodes_visibility' => $course_default_episodes_visibility,
         ];
 
         return $this->createResponse($results, $response);

--- a/lib/Routes/Course/CourseSetDefaultVideosVisibility.php
+++ b/lib/Routes/Course/CourseSetDefaultVideosVisibility.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Opencast\Routes\Course;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Opencast\Errors\AuthorizationFailedException;
+use Opencast\Errors\Error;
+use Opencast\OpencastTrait;
+use Opencast\OpencastController;
+use Opencast\Models\SeminarSeries;
+
+/**
+ * Set the default visibility of videos in a course using the course config
+ */
+class CourseSetDefaultVideosVisibility extends OpencastController
+{
+    use OpencastTrait;
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        global $user, $perm;
+
+        $course_id = $args['course_id'];
+
+        $json = $this->getRequestData($request);
+        $visibility_option = $json['visibility_option'];
+        $possible_visibility_options = ['default', 'visible', 'hidden'];
+
+        if (!in_array($visibility_option, $possible_visibility_options)) {
+            throw new Error('Ungültige Sichtbarkeit!', 422);
+        }
+
+        if (empty($course_id) || empty($visibility_option)) {
+            throw new Error('Es fehlen Parameter!', 422);
+        }
+
+        if (!$perm->have_studip_perm('tutor', $course_id)) {
+            throw new \AccessDeniedException();
+        }
+
+        $response_code = 204;
+        $message = [
+            'type' => 'success',
+            'text' => _('Die Standardsichtbarkeit der Videos wurde aktualisiert.')
+        ];
+        try {
+            \CourseConfig::get($course_id)->store(
+                'OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY',
+                $visibility_option
+            );
+        } catch (\Throwable $e) {
+            $response_code = 500;
+            $message = [
+                'type' => 'error',
+                'text' => _('Beim Aktualisieren der Standardsichtbarkeit ist ein Fehler aufgetreten.')
+            ];
+        }
+
+        return $this->createResponse([
+            'message' => $message,
+        ], $response->withStatus($response_code));
+    }
+}

--- a/migrations/109_add_course_config_default_visibility.php
+++ b/migrations/109_add_course_config_default_visibility.php
@@ -1,0 +1,26 @@
+<?php
+class AddCourseConfigDefaultVisibility extends Migration
+{
+
+
+    public function description()
+    {
+        return 'Create new course config for default visibility of the episodes';
+    }
+
+    public function up()
+    {
+        Config::get()->create('OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY', [
+            'value' => 'default',
+            'type' => 'string',
+            'range' => 'course',
+            'section' => 'opencast',
+            'description' => 'Legt den Sichtbarkeitsstatus für Episoden fest, die den Standardwerten im Kurs folgen.'
+        ]);
+    }
+
+    public function down()
+    {
+        Config::get()->delete('OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY');
+    }
+}

--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -218,6 +218,12 @@
                         </a>
                     </li>
                     <li v-if="canEdit">
+                        <a href="#" @click.prevent="$emit('changeDefaultVisibility')">
+                            <studip-icon style="margin-left: -20px;" :shape="changeDefaultVisibilityIcon" role="clickable"/>
+                            {{ $gettext('Standardsichtbarkeit Videos') }}
+                        </a>
+                    </li>
+                    <li v-if="canEdit">
                         <a href="#" @click.prevent="$emit('copyAll')">
                             <studip-icon style="margin-left: -20px;" shape="export" role="clickable"/>
                             {{ $gettext('Kursinhalte übertragen') }}
@@ -254,7 +260,8 @@ export default {
         'sortVideo',
         'saveSortVideo',
         'cancelSortVideo',
-        'changeDefaultPlaylist'
+        'changeDefaultPlaylist',
+        'changeDefaultVisibility'
     ],
 
     data() {
@@ -362,6 +369,16 @@ export default {
         hasDefaultPlaylist() {
             return this.course_config?.has_default_playlist;
         },
+
+        changeDefaultVisibilityIcon() {
+            let course_hide_episodes = false;
+            if (this.course_config.hasOwnProperty('course_hide_episodes')) {
+                course_hide_episodes = this.course_config.course_hide_episodes;
+            } else if (this.simple_config_list?.settings && this.simple_config_list.settings.hasOwnProperty('OPENCAST_HIDE_EPISODES')) {
+                course_hide_episodes = this.simple_config_list.settings.OPENCAST_HIDE_EPISODES;
+            }
+            return course_hide_episodes ? 'visibility-invisible' : 'visibility-visible';
+        }
     },
 
     methods: {

--- a/vueapp/components/Courses/EpisodesDefaultVisibilityDialog.vue
+++ b/vueapp/components/Courses/EpisodesDefaultVisibilityDialog.vue
@@ -1,0 +1,97 @@
+<template>
+    <div>
+        <StudipDialog
+            :title="$gettext('Standardsichtbarkeit Videos in dieser Veranstaltung')"
+            :confirmText="$gettext('Akzeptieren')"
+            :closeText="$gettext('Schließen')"
+            :closeClass="'cancel'"
+            height="260"
+            width="530"
+            @close="$emit('cancel')"
+            @confirm="setCourseEpisodesVisibility"
+        >
+            <template v-slot:dialogContent>
+                <form class="default" @submit="setCourseEpisodesVisibility">
+                    <label>
+                        <input type="radio" name="visibility" value="default"
+                            :checked="currentVisibilityOption == 'default'"
+                            v-model="visibilityOption"
+                        >
+                        {{ $gettext('Systemstandard') + ' (' + $gettext(standardVisibilityText) + ')' }}
+                    </label>
+
+                    <label>
+                        <input type="radio" name="visibility" value="visible"
+                            :checked="currentVisibilityOption == 'visible'"
+                            v-model="visibilityOption"
+                        >
+                        {{ $gettext('Videos standardmäßig sichtbar für Studierende') }}
+                    </label>
+
+                    <label>
+                        <input type="radio" name="visibility" value="hidden"
+                            :checked="currentVisibilityOption == 'hidden'"
+                            v-model="visibilityOption"
+                        >
+                        {{ $gettext('Videos standardmäßig unsichtbar für Studierende') }}
+                    </label>
+                </form>
+            </template>
+        </StudipDialog>
+    </div>
+</template>
+
+<script>
+import { ref, computed, onBeforeMount } from 'vue'
+import { useStore } from "vuex";
+import { useGettext } from 'vue3-gettext';
+
+import StudipDialog from "@/components/Studip/StudipDialog.vue";
+
+export default {
+    name: "EpisodesDefaultVisibilityDialog",
+    components: {
+        StudipDialog,
+    },
+    emits: ['done', 'cancel'],
+
+    setup(props, { emit }) {
+        const { $gettext } = useGettext();
+        const store = useStore();
+
+        const visibilityOption = ref();
+        const cid = computed(() => store.getters.cid);
+        const standardVisibilityText = computed(() => {
+            return store.getters.simple_config_list?.settings?.OPENCAST_HIDE_EPISODES ?
+            $gettext('Videos standardmäßig unsichtbar für Studierende') : $gettext('Videos standardmäßig sichtbar für Studierende');
+        });
+        const currentVisibilityOption = computed(() => {
+            return store.getters.course_config?.course_default_episodes_visibility ?? 'default';
+        });
+
+        const setCourseEpisodesVisibility = () => {
+            store.dispatch('setCourseEpisodesVisibility', {
+                cid: store.getters.cid,
+                visibility_option: visibilityOption.value
+            }).then((data) => {
+                store.dispatch('loadCourseConfig', store.getters.cid);
+                store.dispatch('loadCourseConfig', store.getters.cid);
+                emit('done');
+            });
+        }
+
+        onBeforeMount(() => {
+            // Make sure that the visibilityOption gets its inital value from computed variable!
+            visibilityOption.value = currentVisibilityOption.value;
+        })
+
+        return {
+            setCourseEpisodesVisibility,
+            currentVisibilityOption,
+            visibilityOption,
+            cid,
+            standardVisibilityText,
+        }
+    }
+}
+</script>

--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -357,11 +357,11 @@ export default {
             }
 
             if (event.seminar_visibility === null || event.seminar_visibility === undefined) {
-                if (this.simple_config_list.settings.OPENCAST_HIDE_EPISODES) {
-                    return false;
-                } else {
-                    return true;
+                if (this.course_config && this.course_config.hasOwnProperty('course_hide_episodes')) {
+                    return this.course_config.course_hide_episodes ? false : true;
                 }
+                // Fallback to global setting, when the course_hide_episodes is not set!
+                return this.simple_config_list.settings.OPENCAST_HIDE_EPISODES ? false : true;
             }
 
             if (event.seminar_visibility?.visibility == 'visible') {
@@ -379,7 +379,8 @@ export default {
             'downloadSetting',
             'videoSortMode',
             'currentUser',
-            'simple_config_list'
+            'simple_config_list',
+            'course_config'
         ]),
 
         showCheckbox() {

--- a/vueapp/store/opencast.module.js
+++ b/vueapp/store/opencast.module.js
@@ -213,7 +213,11 @@ const actions = {
                 user: null
             });
         }
-    }
+    },
+
+    setCourseEpisodesVisibility({ context }, data) {
+        return ApiService.put('courses/' + data.cid + '/episodes_visibility', {visibility_option: data.visibility_option})
+    },
 }
 
 const mutations = {

--- a/vueapp/store/videos.module.js
+++ b/vueapp/store/videos.module.js
@@ -22,6 +22,7 @@ const state = {
     courseVideosToCopy: [],
     showCourseCopyDialog: false,
     videosReload: false,
+    showEpisodesDefaultVisibilityDialog: false,
 }
 
 const getters = {
@@ -76,6 +77,10 @@ const getters = {
     videosReload(state) {
         return state.videosReload
     },
+
+    showEpisodesDefaultVisibilityDialog(state) {
+        return state.showEpisodesDefaultVisibilityDialog
+    }
 }
 
 const actions = {
@@ -260,7 +265,11 @@ const actions = {
 
     setVideosReload({commit}, mode) {
         commit('setVideosReload', mode)
-    }
+    },
+
+    toggleShowEpisodesDefaultVisibilityDialog({commit}, mode) {
+        commit('setShowEpisodesDefaultVisibilityDialog', mode);
+    },
 }
 
 const mutations = {
@@ -327,7 +336,11 @@ const mutations = {
 
     setVideosReload(state, mode) {
         state.videosReload = mode;
-    }
+    },
+
+    setShowEpisodesDefaultVisibilityDialog(state, mode) {
+        state.showEpisodesDefaultVisibilityDialog = mode;
+    },
 }
 
 export default {

--- a/vueapp/views/Course.vue
+++ b/vueapp/views/Course.vue
@@ -8,7 +8,8 @@
                 @cancelSortVideo="cancelSort"
                 @editPlaylist="editPlaylistDialog = true"
                 @changeDefaultPlaylist="showChangeDefaultPlaylistDialog = true"
-                @copyAll="copyAll">
+                @copyAll="copyAll"
+                @changeDefaultVisibility="changeDefaultVisibility">
             </CoursesSidebar>
         </Teleport>
 
@@ -42,6 +43,11 @@
             @cancel="showChangeDefaultPlaylistDialog = false"
         />
 
+        <EpisodesDefaultVisibilityDialog v-if="showEpisodesDefaultVisibilityDialog"
+            @done="closeChangeDefaultVisibility"
+            @cancel="closeChangeDefaultVisibility"
+        />
+
         <MessageList />
 
         <router-view></router-view>
@@ -50,6 +56,7 @@
 
 <script>
 import CoursesSidebar from "@/components/Courses/CoursesSidebar";
+import EpisodesDefaultVisibilityDialog from "@/components/Courses/EpisodesDefaultVisibilityDialog";
 import PlaylistAddVideos from "@/components/Playlists/PlaylistAddVideos";
 import VideoUpload from "@/components/Videos/VideoUpload";
 import MessageList from "@/components/MessageList";
@@ -67,7 +74,8 @@ export default {
         PlaylistsLinkCard, PlaylistAddCard,
         PlaylistEditCard, CoursesSidebar,
         VideoUpload, PlaylistAddVideos,
-        MessageList, VideoCopyToSeminar
+        MessageList, VideoCopyToSeminar,
+        EpisodesDefaultVisibilityDialog
     },
 
     computed: {
@@ -77,7 +85,8 @@ export default {
             'showPlaylistAddVideosDialog',
             'addPlaylist',
             'cid',
-            'course_config'
+            'course_config',
+            'showEpisodesDefaultVisibilityDialog',
         ]),
 
         canEdit() {
@@ -154,6 +163,14 @@ export default {
         resetCopyParams() {
             this.$store.dispatch('toggleCourseCopyDialog', false);
             this.$store.dispatch('setCourseVideosToCopy', []);
+        },
+
+        changeDefaultVisibility() {
+            this.$store.dispatch('toggleShowEpisodesDefaultVisibilityDialog', true);
+        },
+
+        closeChangeDefaultVisibility() {
+            this.$store.dispatch('toggleShowEpisodesDefaultVisibilityDialog', false);
         }
     },
 


### PR DESCRIPTION
This PR fixes #1316.

### What's New
- A new course config `OPENCAST_COURSE_DEFAULT_EPISODES_VISIBILITY` via migration no. 109!
- A new **sidebar action** has been added to open a dialog that allows course administrators to configure the **default visibility of episodes** for the course.
- This setting applies only to episodes that currently have their visibility set to **"default"**.

### Configuration Options
The visibility (for students in a course) can be set to:
- Follow the global setting (`OPENCAST_HIDE_EPISODES`)
- Always be **visible** by default
- Always be **hidden** by default

This change improves flexibility by allowing **per-course control** over the default visibility behavior of episodes, overriding the global default if needed.
