### PR TITLE
Fix cw copy for empty opencast blocks

### DIFF
--- a/lib/BlockTypes/OpencastBlockV3.php
+++ b/lib/BlockTypes/OpencastBlockV3.php
@@ -63,7 +63,9 @@ class OpencastBlockV3 extends BlockType
         $token = md5($this->block['id'] . time());
         $payload['copied_token'] = $token;
 
-        CoursewareBlockMappings::setRecord($token, $payload['token'], $rangeId);
+        if (!empty($payload['token'])) {
+            CoursewareBlockMappings::setRecord($token, $payload['token'], $rangeId);
+        }
 
         return $payload;
     }


### PR DESCRIPTION
Fixes the problem of missing token in opencast block payload during copy:

```
Exception: Could not store course mappings, missing data. in public/plugins_packages/elan-ev/OpencastV3/lib/Models/CoursewareBlockMappings.php:34
Stack trace:
#0 public/plugins_packages/elan-ev/OpencastV3/lib/BlockTypes/OpencastBlockV3.php(66): Opencast\Models\CoursewareBlockMappings::setRecord()
#1 lib/models/Courseware/Block.php(206): OpencastBlockV3->copyPayload()
#2 lib/models/Courseware/Container.php(163): Courseware\Block->copy()
#3 lib/models/Courseware/Container.php(148): Courseware\Container->copyBlocks()
#4 lib/models/Courseware/StructuralElement.php(1010): Courseware\Container->copy()
#5 lib/models/Courseware/StructuralElement.php(905): Courseware\StructuralElement->copyContainers()
#6 lib/models/Courseware/StructuralElement.php(1020): Courseware\StructuralElement->copy()
#7 lib/models/Courseware/Structur" while reading response header from upstream, request: "POST /jsonapi.php/v1/courseware-units/8499/copy HTTP/1.1"
```