### PR TITLE
Show correct video duration

### DIFF
--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -980,7 +980,7 @@ class Videos extends UPMap
             $presentation_download = [];
             $audio_download        = [];
             $annotation_tool       = false;
-            $duration              = 0;
+            $duration              = $video->duration;
             $track_link            = '';
             $livestream_link       = '';
 


### PR DESCRIPTION
Replaces the initial 0 duration by the stored video duration in the DB.

Fix #1157