### PR TITLE
Transfer the value of OPENCAST_ALLOW_MEDIADOWNLOAD config to OPENCAST_MEDIADOWNLOAD

### DIFF
--- a/migrations/062_add_config_custom_download.php
+++ b/migrations/062_add_config_custom_download.php
@@ -15,8 +15,13 @@ class AddConfigCustomDownload extends Migration
             ADD COLUMN `allow_download` boolean DEFAULT NULL");
         $db->exec("ALTER TABLE `oc_video`
             ADD COLUMN `allow_download` boolean DEFAULT NULL");
+
+        // Get the current value of the config and map to new config value.
+        $current_media_download_config = (bool) Config::get()->OPENCAST_ALLOW_MEDIADOWNLOAD ?? null;
+        $new_config_value = $current_media_download_config === true ? 'allow' : 'never';
+
         $db->exec("DELETE FROM `config` WHERE `field`='OPENCAST_ALLOW_MEDIADOWNLOAD'");
-        
+
         $stmt = $db->prepare('INSERT IGNORE INTO config (field, value, section, type, `range`, mkdate, chdate, description)
                               VALUES (:name, :value, :section, :type, :range, UNIX_TIMESTAMP(), UNIX_TIMESTAMP(), :description)');
         $stmt->execute([
@@ -25,7 +30,7 @@ class AddConfigCustomDownload extends Migration
             'description' => 'Erlaubnis für Mediendownloads verwalten.',
             'range'       => 'global',
             'type'        => 'string',
-            'value'       => 'never'
+            'value'       => $new_config_value
         ]);
 
         SimpleOrMap::expireTableScheme();
@@ -34,6 +39,10 @@ class AddConfigCustomDownload extends Migration
     public function down()
     {
         $db = DBManager::get();
+
+        // Revert the config value with mapping to the old config.
+        $new_media_download_config = (string) Config::get()->OPENCAST_MEDIADOWNLOAD ?? 'never';
+        $old_config_value = $new_media_download_config !== 'allow' ? true : false;
 
         $db->exec("DELETE FROM config WHERE field = 'OPENCAST_MEDIADOWNLOAD'");
         $db->exec("ALTER TABLE `oc_playlist` DROP COLUMN `allow_download`");
@@ -47,7 +56,7 @@ class AddConfigCustomDownload extends Migration
             'description' => 'Wird Nutzern angeboten, Aufzeichnungen herunterzuladen?',
             'range'       => 'global',
             'type'        => 'boolean',
-            'value'       => true
+            'value'       => $old_config_value
         ]);
 
         SimpleOrMap::expireTableScheme();


### PR DESCRIPTION
This PR fixes #1146.
During the migration we capture the current value of old config and map it into the new config value. Since the old one is boolean we consider only 'never' and 'allow' values for the new one!