### PR TITLE
Fix allow media download action

### DIFF
--- a/lib/Models/PlaylistSeminars.php
+++ b/lib/Models/PlaylistSeminars.php
@@ -31,10 +31,10 @@ class PlaylistSeminars extends \SimpleORMap
 
         // Always prioritise allow download property of seminar playlist
         if (!is_null($this->allow_download)) {
-            $playlist_data['allow_download'] = $this->allow_download;
+            $playlist_data['allow_download'] = (bool) $this->allow_download;
         }
 
-        $playlist_data['is_default'] = $this->is_default;
+        $playlist_data['is_default'] = (bool) $this->is_default;
 
         $playlist_data['contains_scheduled'] = (bool) $this->contains_scheduled;
         $playlist_data['contains_livestreams'] = (bool) $this->contains_livestreams;

--- a/vueapp/components/Courses/CoursesSidebar.vue
+++ b/vueapp/components/Courses/CoursesSidebar.vue
@@ -44,7 +44,7 @@
                                 <span class="oc--playlist-title">
                                     {{ p.title }}
                                 </span>
-                                <div v-if="p.is_default == 1"
+                                <div v-if="p.is_default == true"
                                     class="tooltip oc--playlist-default-icon" :data-tooltip="$gettext('Standard-Kurswiedergabeliste')">
                                     <studip-icon shape="check-circle" :role="playlist?.token == p.token ? 'info_alt' : 'clickable'" :size="16"/>
                                 </div>

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -143,7 +143,7 @@
 
                         <span v-if="isCourse && playlist && canEdit">
                             <StudipButton class="wrap-button"
-                                          v-if="playlist.is_default != '1'"
+                                          v-if="playlist.is_default != true"
                                           @click.prevent="removePlaylist(playlist.token, cid)"
                             >
                                 <studip-icon shape="trash" role="clickable" />

--- a/vueapp/store/playlists.module.js
+++ b/vueapp/store/playlists.module.js
@@ -30,7 +30,7 @@ const getters = {
     defaultPlaylist(state) {
         // Find the courses default playlist
         for (let id in state.playlists) {
-            if (state.playlists[id].is_default == '1') {
+            if (state.playlists[id].is_default == true) {
                 return state.playlists[id];
             }
         }
@@ -200,7 +200,7 @@ const actions = {
             let is_default = false;
 
             // Set first playlist as default
-            if (data?.is_default === true && index === 0) {
+            if (data?.is_default == true && index === 0) {
                 is_default = true;
             }
 


### PR DESCRIPTION
The issue #1336 is caused by https://gitlab.studip.de/studip/studip/-/issues/5382. This patch casts the values of `allow_download` and `is_default` to boolean values to prevent the javascript condition evaluation of `"0"` as a `true` value, see https://developer.mozilla.org/en-US/docs/Glossary/Truthy.

Fix #1336