### PR TITLE
Refactor migration logic for preview URLs and add fix for orphaned previews

### DIFF
--- a/migrations/110_fix_orphaned_previews.php
+++ b/migrations/110_fix_orphaned_previews.php
@@ -1,10 +1,10 @@
 <?php
 
-class MigratePreviews extends Migration
+class FixOrphanedPreviews extends Migration
 {
     public function description()
     {
-        return 'Update preview URL in oc_video table';
+        return 'Fix for previews that could not get migrated in 107.';
     }
 
     public function up()
@@ -19,19 +19,20 @@ class MigratePreviews extends Migration
             $new_preview_url = null;
             $previews = json_decode($data['preview'], true);
 
+            // We want to handle the case where the preview is still a json object.
             if (!empty($previews)) {
+                // Last chance to present the preview URL.
                 if (!empty($previews['player'])) {
                     $new_preview_url = $previews['player'];
                 } else if (!empty($previews['search'])) {
                     $new_preview_url = $previews['search'];
                 }
-            }
 
-            // Since we are migrating previews to preview URL, we update the preview regardless of the value of the new preview url, whether it is empty or not!
-            $stmt->execute([
-                ':preview' => $new_preview_url,
-                ':id' => $data['id']
-            ]);
+                $stmt->execute([
+                    ':preview' => $new_preview_url,
+                    ':id' => $data['id']
+                ]);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes #1319,

It considts of 2 parts, first the fix for migration 107, in which the problem was that the update only happened when the new preview has a value, which ends up with not updating those previews that have no search/player. The second part, is a fix via a new migration step, by which it reads the previews again and try to locate the orphaned previews with json decoded string and then update them either with null or an URL value.