### PR TITLE
Video embedding code

### DIFF
--- a/assets/css/opencast.scss
+++ b/assets/css/opencast.scss
@@ -1322,3 +1322,12 @@ label.oc--file-upload {
     position: sticky;
     bottom: 0px;
 }
+
+/* * * * * * * * * * * * * * * * * */
+/*   E M B E D D I N G   C O D E   */
+/* * * * * * * * * * * * * * * * * */
+
+.oc--embedding-code-text {
+    width: 100%;
+    box-sizing: border-box;
+}

--- a/lib/Routes/Config/SimpleConfigList.php
+++ b/lib/Routes/Config/SimpleConfigList.php
@@ -37,6 +37,7 @@ class SimpleConfigList extends OpencastController
                 'id'            => $conf->id,
                 'name'          => $conf->service_url,
                 'version'       => $conf->service_version,
+                'play'          => reset(Endpoints::findBySql("config_id = ? AND service_type = 'play'", [$conf->id]))->service_url,
                 'ingest'        => reset(Endpoints::findBySql("config_id = ? AND service_type = 'ingest'", [$conf->id]))->service_url,
                 'apievents'     => reset(Endpoints::findBySql("config_id = ? AND service_type = 'apievents'", [$conf->id]))->service_url,
                 'apiplaylists'  => reset(Endpoints::findBySql("config_id = ? AND service_type = 'apiplaylists'", [$conf->id]))->service_url,

--- a/vueapp/components/Videos/Actions/VideoAccess.vue
+++ b/vueapp/components/Videos/Actions/VideoAccess.vue
@@ -139,6 +139,11 @@
                                 {{  $gettext('Links zu den Mediendateien anzeigen.') }}
                                 <studip-icon shape="link-intern" role="clickable" />
                             </a>
+                            <br>
+                            <a style="cursor: pointer" @click.stop="performAction('VideoEmbeddingCode')">
+                                {{  $gettext('Einbettungscode anzeigen.') }}
+                                <studip-icon shape="link-intern" role="clickable" />
+                            </a>
                             <br><br>
 
                             <StudipButton icon="trash"

--- a/vueapp/components/Videos/Actions/VideoEmbeddingCode.vue
+++ b/vueapp/components/Videos/Actions/VideoEmbeddingCode.vue
@@ -1,0 +1,86 @@
+<template>
+    <div>
+        <StudipDialog
+            :title="$gettext('Einbettungscode')"
+            :closeText="$gettext('Schließen')"
+            :closeClass="'cancel'"
+            height="400"
+            width="550"
+            @close="this.$emit('cancel')"
+        >
+            <template v-slot:dialogContent>
+                <textarea v-model="embeddingCode" rows="5" class="oc--embedding-code-text" readonly></textarea>
+
+                <StudipButton
+                    :disabled="!embeddingCode"
+                    @click.prevent="copyEmbeddingCode()"
+                >
+                    {{ $gettext('Einbettungscode kopieren') }}
+                </StudipButton>
+
+                <MessageList :dialog="true" />
+            </template>
+        </StudipDialog>
+    </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+import StudipDialog from '@studip/StudipDialog'
+import StudipButton from '@studip/StudipButton'
+import MessageList from '@/components/MessageList.vue';
+
+export default {
+    name: 'VideoEmbeddingCode',
+
+    components: {
+        StudipDialog,
+        StudipButton,
+        MessageList,
+    },
+
+    props: ['event'],
+
+    computed: {
+        ...mapGetters([
+            'simple_config_list'
+        ]),
+        url() {
+            if (this.event.config_id === undefined) {
+                return null;
+            }
+
+            if (this.simple_config_list?.server?.[this.event.config_id]?.play === undefined) {
+                return null;
+            }
+
+            return this.simple_config_list.server[this.event.config_id].play + '/' + this.event.episode;
+        },
+        embeddingCode() {
+            if (!this.url) {
+                return null;
+            }
+
+            return `<iframe allowfullscreen src="${this.url}" style="border: 0; margin 0;" name="Player"></iframe>`;
+        },
+    },
+
+    methods: {
+        copyEmbeddingCode() {
+            navigator.clipboard.writeText(this.embeddingCode).then(() => {
+                this.$store.dispatch('addMessage', {
+                    type: 'success',
+                    text: this.$gettext('Der Einbettungscode wurde in die Zwischenablage kopiert.'),
+                    dialog: true
+                });
+            }).catch(() => {
+                this.$store.dispatch('addMessage', {
+                    type: 'error',
+                    text: this.$gettext('Der Einbettungscode konnte nicht in die Zwischenablage kopiert werden.'),
+                    dialog: true
+                });
+            });
+        },
+    },
+}
+</script>

--- a/vueapp/components/Videos/VideoRow.vue
+++ b/vueapp/components/Videos/VideoRow.vue
@@ -512,6 +512,16 @@ export default {
                         });
                     }
 
+                    if (this.canShare && this.event.visibility === 'public') {
+                        menuItems.push({
+                            id: 4,
+                            label: this.$gettext('Einbettungscode anzeigen'),
+                            icon: 'code',
+                            emit: 'performAction',
+                            emitArguments: 'VideoEmbeddingCode'
+                        });
+                    }
+
                     // As we abandoned the preview object structure, we now have to only validate the preview URL!
                     if ((this.event?.preview || this.event?.state == 'cutting') && !this.isLivestream) {
                         menuItems.push({

--- a/vueapp/components/Videos/VideosTable.vue
+++ b/vueapp/components/Videos/VideosTable.vue
@@ -187,6 +187,7 @@ import VideoEdit from '@/components/Videos/Actions/VideoEdit.vue';
 import VideoCut from '@/components/Videos/Actions/VideoCut.vue';
 import VideoRestore from '@/components/Videos/Actions/VideoRestore.vue';
 import VideoRemoveFromPlaylist from '@/components/Videos/Actions/VideoRemoveFromPlaylist.vue';
+import VideoEmbeddingCode from '@/components/Videos/Actions/VideoEmbeddingCode.vue';
 
 import BulkVideoDelete from '@/components/Videos/BulkActions/VideoDelete.vue';
 import BulkVideoDeletePermanent from '@/components/Videos/BulkActions/VideoDeletePermanent.vue';
@@ -209,8 +210,8 @@ export default {
         VideoEdit,                VideoCut,
         VideoRestore,             VideoDelete,
         VideoDeletePermanent,     VideoRemoveFromPlaylist,
-        BulkVideoDelete,          BulkVideoDeletePermanent,
-        BulkVideoRestore,
+        VideoEmbeddingCode,       BulkVideoDelete,
+        BulkVideoDeletePermanent, BulkVideoRestore,
         draggable,
     },
 


### PR DESCRIPTION
Displays a dialog containing an iframe embedding code for external websites. This code is only visible when the video is accessible worldwide.

The oc admin interface offers a size selection. As I do not know whether this function is required, this feature doesn't include such a selection.

Screenshots:
![image](https://github.com/user-attachments/assets/7d9a6584-4da0-46a8-baf0-3cb12cb8e643)
![image](https://github.com/user-attachments/assets/524f0aab-d8ad-478d-b4f4-167ea12669c6)
![image](https://github.com/user-attachments/assets/2637c876-952f-46d7-9b17-cc4c76953a63)

Close #1112