### PR TITLE
Show and log video upload errors

### DIFF
--- a/vueapp/common/upload.service.js
+++ b/vueapp/common/upload.service.js
@@ -372,13 +372,13 @@ class UploadService {
                         uploadDone(episode_id, terms, workflowId);
                     }
                 } catch (ex) {
-                    console.log(ex);
+                    console.error(ex);
+                    onError();
                     /* Catch XML parse error. On Error Resume Next ;-) */
                 }
             }).catch(function (error) {
-                if (error.code === 'ERR_NETWORK') {
-                    onError();
-                }
+                console.error(error);
+                onError();
             });
     }
 


### PR DESCRIPTION
This patch always shows an error message to users if the upload fails and logs the error into the browser console.