### PR TITLE
Make sure event has required properties before any operation when discovering events

### DIFF
--- a/cronjobs/opencast_discover_videos.php
+++ b/cronjobs/opencast_discover_videos.php
@@ -13,6 +13,13 @@ use Opencast\Models\REST\ApiEventsClient;
 class OpencastDiscoverVideos extends CronJob
 {
 
+    /**
+     * @var array The required properties of the event object which will be checked before any operation.
+     */
+    private static $required_event_properties = [
+        'archive_version'
+    ];
+
     public static function getName()
     {
         return _('Opencast - Neue Videos finden');
@@ -26,8 +33,8 @@ class OpencastDiscoverVideos extends CronJob
     public function execute($last_result, $parameters = array())
     {
         /*
-         - Neue Videos in OC identifizieren (die Stud.IP noch nicht kennt)
-         - Eintragen der Videos und setzen der Rechte (Queue)
+            - Neue Videos in OC identifizieren (die Stud.IP noch nicht kennt)
+            - Eintragen der Videos und setzen der Rechte (Queue)
         */
         $db = DBManager::get();
         $stmt_ids = $db->prepare("
@@ -93,6 +100,12 @@ class OpencastDiscoverVideos extends CronJob
                 // load events from opencast and filter the processed ones
                 if (!empty($oc_events)) foreach ($oc_events as $event) {
                     $current_event = null;
+
+                    // Check the required properties of the event.
+                    if (!self::checkEventIntegrity($event)) {
+                        echo '[Skipped] The event does not have all required properties, skipping: ' . $event->identifier . "\n";
+                        continue;
+                    }
 
                     // only add videos / reinspect videos if they are readily processed
                     if ($event->status == 'EVENTS.EVENTS.STATUS.PROCESSED') {
@@ -195,6 +208,23 @@ class OpencastDiscoverVideos extends CronJob
             WHERE visibility IS NULL or visibility = ''");
 
         echo 'Finished updating videos and workflows' . "\n";
+    }
+
+    /**
+     * Check if the event has all required properties.
+     *
+     * @param object $event The event object to check.
+     * @return bool True if the event has all required properties, false otherwise.
+     */
+    private static function checkEventIntegrity($event) {
+        // Check if the event has all required properties
+        foreach (self::$required_event_properties as $property) {
+            if (!property_exists($event, $property)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static function parseEvent($event, $video)


### PR DESCRIPTION
This PR fixes #1271,

It includes a mechanism that checks the integrity of the event before any operation by checking properties against a local array which can be adjusted later on!