### PR TITLE
Handle null episode in check event acl

### DIFF
--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -886,7 +886,9 @@ class Videos extends UPMap
         // Fetch episode if null
         if (empty($episode)) {
             $api_client  = ApiEventsClient::getInstance($video->config_id);
-            $episode = $api_client->getEpisode($video->episode);
+            $episode = $api_client->getEpisode($video->episode, [
+                'withacl' => 'true'
+            ]);
         }
 
         // Only allow updating of metadata if event has publications

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -875,13 +875,13 @@ class Videos extends UPMap
      *
      * @Notification OpencastVideoSync
      *
-     * @param string|null           $eventType
-     * @param object|null           $episode
-     * @param Opencast\Models\Video $video
+     * @param string|null $eventType
+     * @param object|null $episode
+     * @param Videos      $video
      *
      * @return void
      */
-    public static function checkEventACL($eventType, $episode, $video)
+    public static function checkEventACL(?string $eventType, ?object $episode, Videos $video)
     {
         // Fetch episode if null
         if (empty($episode)) {

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -883,6 +883,12 @@ class Videos extends UPMap
      */
     public static function checkEventACL($eventType, $episode, $video)
     {
+        // Fetch episode if null
+        if (empty($episode)) {
+            $api_client  = ApiEventsClient::getInstance($video->config_id);
+            $episode = $api_client->getEpisode($video->episode);
+        }
+
         // Only allow updating of metadata if event has publications
         if (!Helpers::canEventRunWorkflow($episode, $video)) {
             return;

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -875,8 +875,8 @@ class Videos extends UPMap
      *
      * @Notification OpencastVideoSync
      *
-     * @param string                $eventType
-     * @param object                $episode
+     * @param string|null           $eventType
+     * @param object|null           $episode
      * @param Opencast\Models\Video $video
      *
      * @return void


### PR DESCRIPTION
Users have no permissions on videos added from the work place. This patch fixes this problem by fetching the episode from opencast if the `$episode` parameter is null.