### PR TITLE
Add course series verification and related API integration [Course Series Auto re-creation]

### DIFF
--- a/lib/Models/REST/SeriesClient.php
+++ b/lib/Models/REST/SeriesClient.php
@@ -25,16 +25,23 @@ class SeriesClient extends RestClient
      * Retrieve series metadata for a given series identifier from Opencast
      *
      * @param string series_id Identifier for a Series
+     * @param bool check_existence a flag to check the existence of the series
      *
-     * @return array|boolean response of a series, or false if unable to get
+     * @return mix [array|boolean|int] response of a series, or false if unable to get or 404 if not found and $check_existence is true
      */
-    public function getSeries($series_id)
+    public function getSeries($series_id, $check_existence = false)
     {
         $response = $this->opencastApi->series->get($series_id);
 
         if ($response['code'] == 200) {
             return $response['body'];
         }
+
+        if ($check_existence && $response['code'] == 404) {
+            // Series not found, so we return 404!
+            return 404;
+        }
+
         return false;
     }
 

--- a/lib/RouteMap.php
+++ b/lib/RouteMap.php
@@ -101,6 +101,7 @@ class RouteMap
 
         $group->get("/courses/{course_id}/config", Routes\Course\CourseConfig::class);
         $group->get("/courses/{course_id}/playlists", Routes\Course\CourseListPlaylist::class);
+        $group->post("/courses/{course_id}/verifyCourseSeriesExists", Routes\Course\CourseSeriesVerification::class);
 
         $group->get("/courses/{course_id}/{semester_filter}/schedule", Routes\Course\CourseListSchedule::class);
 

--- a/lib/Routes/Course/CourseConfig.php
+++ b/lib/Routes/Course/CourseConfig.php
@@ -34,12 +34,14 @@ class CourseConfig extends OpencastController
 
         $series = SeminarSeries::findOneBySeminar_id($course_id);
 
+        $config_id = $series->config_id ?? \Config::get()->OPENCAST_DEFAULT_SERVER;
+
         if (empty($series)) {
             // only tutor or above should be able to trigger this series creation!
             $required_course_perm = \Config::get()->OPENCAST_TUTOR_EPISODE_PERM ? 'tutor' : 'dozent';
             if ($perm->have_studip_perm($required_course_perm, $course_id)) {
                 // No series for this course yet! Create one!
-                $config_id = \Config::get()->OPENCAST_DEFAULT_SERVER;
+
                 $series_client = new SeriesClient($config_id);
                 $series_id = $series_client->createSeriesForSeminar($course_id);
 
@@ -79,6 +81,8 @@ class CourseConfig extends OpencastController
             'scheduling_allowed'                 => Perm::schedulingAllowed($course_id),
             'course_hide_episodes'               => $course_hide_episodes, // Use this in a course instead of OPENCAST_HIDE_EPISODES!
             'course_default_episodes_visibility' => $course_default_episodes_visibility,
+            // To make is easier to recognize the server in the frontend
+            'config_id'                          => $config_id,
         ];
 
         return $this->createResponse($results, $response);

--- a/lib/Routes/Course/CourseSeriesVerification.php
+++ b/lib/Routes/Course/CourseSeriesVerification.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Opencast\Routes\Course;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Opencast\Errors\Error;
+use Opencast\OpencastTrait;
+use Opencast\OpencastController;
+use Opencast\Models\SeminarSeries;
+use Opencast\Models\REST\SeriesClient;
+use Opencast\Providers\Perm;
+
+
+/**
+ * Make sure that a series exists for the course. If not, create a new one!
+ */
+class CourseSeriesVerification extends OpencastController
+{
+    use OpencastTrait;
+
+    public function __invoke(Request $request, Response $response, $args)
+    {
+        global $perm;
+
+        $course_id = $args['course_id'];
+        $json = $this->getRequestData($request);
+
+        $series_id = $json['series_id'] ?? null;
+        if (empty($series_id) || empty($course_id)) {
+            throw new Error('Es fehlen Parameter!', 422);
+        }
+
+        $config_id = $json['config_id'] ?? \Config::get()->OPENCAST_DEFAULT_SERVER;
+
+        // Check if user has proper right to perform this action.
+        // [User must be enrolled in the seminar]
+        // [User must have the right to upload in the seminar!]
+        if (!$perm->have_studip_perm('user', $course_id) || !Perm::uploadAllowed($course_id)) {
+            // throw new \AccessDeniedException();
+            // If the user does not have the right to upload, we don't throw an error, but we return a message that this process cannot be performed!
+            return $this->createResponse([
+                'message' => [
+                    'type' => 'warning',
+                    'text' => _('Die Überprüfung der Serie ist nicht möglich!'),
+                ]
+            ], $response);
+        }
+
+        // Default message, not necessarily needed, but it makes it easier to understand what is going on and makes the debugging and higher level information easier.
+        $message = [
+            'type' => 'success',
+            'text' => _('Die Serie ist gültig.'),
+        ];
+        try {
+            // Set a flag to force re-creationg of the series in Opencast.
+            $recreate_series_needed = false;
+            $series = SeminarSeries::findBySeries_id($series_id);
+
+            if (empty($series)) {
+                // If the series is not found, we need to create one.
+                $recreate_series_needed = true;
+            } else {
+                // If the series is found, we need to check if it is still valid.
+                $series_client = new SeriesClient($config_id);
+                $series_data = $series_client->getSeries($series_id, true);
+                if ($series_data == 404) {
+                    $recreate_series_needed = true;
+                }
+            }
+
+            if ($recreate_series_needed) {
+
+                $series_client = new SeriesClient($config_id);
+                $series_id = $series_client->createSeriesForSeminar($course_id);
+
+                if ($series_id) {
+                    $series = SeminarSeries::create([
+                        'config_id'  => $config_id,
+                        'seminar_id' => $course_id,
+                        'series_id'  => $series_id,
+                    ]);
+                    $series->store();
+                }
+                // The goal is to create a new one when it does not exist, so we return 201 Created.
+                return $response->withStatus(201);
+            }
+        } catch (\Throwable $th) {
+            // If something goes wrong, we catch the error and return the message but in 200 code so that it does not break the flow of the application.
+            $message = [
+                'type' => 'error',
+                'text' => _('Die Überprüfung der Serie ist fehlergeschlagen') . ': ' . $th->getMessage(),
+            ];
+        }
+
+        return $this->createResponse([
+            'message' => $message,
+        ], $response);
+    }
+}

--- a/vueapp/store/config.module.js
+++ b/vueapp/store/config.module.js
@@ -75,6 +75,15 @@ export const actions = {
             });
     },
 
+    async verifyCourseSeriesExists(context, params) {
+        return ApiService.post('courses/' + params.cid + '/verifyCourseSeriesExists',
+            {
+                config_id: params.config_id,
+                series_id: params.series_id
+            }
+        );
+    },
+
     async configListUpdate(context, params) {
         return  ApiService.put('global_config', params);
     },


### PR DESCRIPTION
This PR fixes #1348,

following the suggestion in: https://github.com/elan-ev/studip-opencast-plugin/issues/1348#issuecomment-2915343568

- Implemented `verifyCourseSeriesExists` action in Vuex store to check if a series exists for a course.
- Enhanced `mounted` lifecycle method in `Course.vue` to verify course series and notify users if a new series is created. (in async)
- Updated `getSeries` method in `SeriesClient` to return 404 status if the series does not exist and check_existence flag is true.
- Introducing `CourseSeriesVerification` REST Endpoint to handle series existence checks and creation logic.
- Permission logic
  - User must be enrolled to the course
  - By using `Perm::uploadAllowed` we make sure that the user right is sufficient to perform the action.