### PR TITLE
Mark videos unavailable in discovery instead of removing + Opencast API connectivity check in cronjobs

### DIFF
--- a/cronjobs/opencast_clear_recycle_bin.php
+++ b/cronjobs/opencast_clear_recycle_bin.php
@@ -4,9 +4,13 @@ require_once __DIR__.'/../vendor/autoload.php';
 
 
 use Opencast\Models\Videos;
+use Opencast\Models\REST\ApiEventsClient;
+use Opencast\Helpers\CronjobUtils\OpencastConnectionCheckerTrait;
 
 class OpencastClearRecycleBin extends CronJob
 {
+
+    use OpencastConnectionCheckerTrait;
 
     public static function getName()
     {
@@ -28,13 +32,37 @@ class OpencastClearRecycleBin extends CronJob
             ) AND trashed_timestamp
                 < NOW() - INTERVAL " . \Config::get()->OPENCAST_CLEAR_RECYCLE_BIN_INTERVAL ." DAY");
 
+        // We need to group the videos based on the config_id, in order to check the connection first.
+        $videos_by_config = [];
         foreach ($videos as $video) {
-            echo "Video #" . $video->id . " (" . $video->title . ") ";
-            if ($video->removeVideo()) {
-                echo "removed\n";
+            $config_id = $video->config_id ?? \Config::get()->OPENCAST_DEFAULT_SERVER;
+            if (!isset($videos_by_config[$config_id])) {
+                $videos_by_config[$config_id] = [];
             }
-            else {
-                echo "remove failed\n";
+            $videos_by_config[$config_id][] = $video;
+        }
+
+        // Now, we loop through the grouped videos.
+        foreach ($videos_by_config as $config_id => $videos) {
+            echo 'Working on config with id #' . $config_id . "\n";
+
+            // Checking the connection.
+            if (!$this->isOpencastReachable($config_id)) {
+                continue;
+            }
+
+            // To increase performance we instantiate the ApiEndpoint once in here!
+            $api_event_client = ApiEventsClient::getInstance($config_id);
+
+            // Deleting videos.
+            foreach ($videos as $video) {
+                echo "Video #" . $video->id . " (" . $video->title . ") ";
+                if ($video->removeVideo($api_event_client)) {
+                    echo "removed\n";
+                }
+                else {
+                    echo "remove failed\n";
+                }
             }
         }
     }

--- a/cronjobs/opencast_refresh_scheduling.php
+++ b/cronjobs/opencast_refresh_scheduling.php
@@ -11,9 +11,12 @@ use Opencast\Models\ScheduledRecordings;
 use Opencast\Models\Resources;
 use Opencast\Models\ScheduleHelper;
 use Opencast\Models\REST\SchedulerClient;
+use Opencast\Helpers\CronjobUtils\OpencastConnectionCheckerTrait;
 
 class OpencastRefreshScheduling extends CronJob
 {
+
+    use OpencastConnectionCheckerTrait;
 
     /**
      * Return the name of the cronjob.
@@ -43,9 +46,15 @@ class OpencastRefreshScheduling extends CronJob
         $oc_se_count = 0;
 
         // 1. Get Opencast Scheduled Recordings based on each configured server config.
-        foreach ($config as $conf) {
-            $config_id = $conf['id'];
+        foreach ($config as $config) {
+            $config_id = $config->id;
             $scheduled_events = [];
+
+            echo 'Working on config with id #' . $config_id . "\n";
+
+            if (!$this->isOpencastReachable($config_id)) {
+                continue;
+            }
 
             try {
                 $events_client = ApiEventsClient::getInstance($config_id);

--- a/cronjobs/opencast_sync_playlists.php
+++ b/cronjobs/opencast_sync_playlists.php
@@ -6,10 +6,12 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Opencast\Models\Config;
 use Opencast\Models\Playlists;
 use Opencast\Models\REST\ApiPlaylistsClient;
-use Opencast\Models\REST\Config as OCConfig;
+use Opencast\Helpers\CronjobUtils\OpencastConnectionCheckerTrait;
 
 class OpencastSyncPlaylists extends CronJob
 {
+    use OpencastConnectionCheckerTrait;
+
     public static function getName()
     {
         return _('Opencast - Wiedergabelisten synchronisieren');
@@ -31,17 +33,10 @@ class OpencastSyncPlaylists extends CronJob
         $configs = Config::findBySql('active = 1');
 
         foreach ($configs as $config) {
-            // check, if this opencast instance is accessible
-            $version = false;
+            echo 'Working on config with id #' . $config->id . "\n";
 
-            echo 'working on config ' . $config->id . "\n";
-            $version = OCConfig::getOCBaseVersion($config->id);
-
-            if (!$version) {
-                echo 'cannot connect to opencast, skipping!' . "\n";
+            if (!$this->isOpencastReachable($config->id)) {
                 continue;
-            } else {
-                echo "found opencast with version $version, continuing\n";
             }
 
             // call opencast to get all playlists

--- a/lib/Helpers/CronjobUtils/OpencastConnectionCheckerTrait.php
+++ b/lib/Helpers/CronjobUtils/OpencastConnectionCheckerTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Opencast\Helpers\CronjobUtils;
+
+use Opencast\Models\REST\Config as OCConfig;
+
+trait OpencastConnectionCheckerTrait
+{
+    /**
+     * @var string $not_reachable_message Message to display when Opencast is not reachable.
+     */
+    private $not_reachable_message = 'Opencast is currently unreachable. Process postponed.';
+
+    /**
+     * Checks if the Opencast instance is reachable for the given configuration ID.
+     *
+     * This method attempts to connect to the Opencast API using the provided configuration ID.
+     * If the connection is successful, it returns true. If not, it prints a message and returns false.
+     * Use this method in cronjob classes before performing any operations that require a working Opencast connection.
+     *
+     * @param int $config_id The ID of the Opencast configuration to check.
+     * @return bool True if Opencast is reachable, false otherwise.
+     */
+    protected function isOpencastReachable(int $config_id): bool {
+        $is_opencast_reachable = false;
+        $message = $this->not_reachable_message;
+        try {
+            $is_opencast_reachable = OCConfig::checkOpencastAPIConnectivity($config_id);
+        } catch (\Throwable $th) {
+            $message .= ': ' . $th->getMessage();
+        }
+        if (!$is_opencast_reachable) {
+            echo $message;
+        }
+        return $is_opencast_reachable;
+    }
+}

--- a/lib/Helpers/CronjobUtils/OpencastConnectionCheckerTrait.php
+++ b/lib/Helpers/CronjobUtils/OpencastConnectionCheckerTrait.php
@@ -19,18 +19,19 @@ trait OpencastConnectionCheckerTrait
      * Use this method in cronjob classes before performing any operations that require a working Opencast connection.
      *
      * @param int $config_id The ID of the Opencast configuration to check.
+     * @param bool $check_engage_node A flag to determine whether the check should be performed against engage node (e.g play or search endpoint)
      * @return bool True if Opencast is reachable, false otherwise.
      */
-    protected function isOpencastReachable(int $config_id): bool {
+    protected function isOpencastReachable(int $config_id, bool $check_engage_node = false): bool {
         $is_opencast_reachable = false;
         $message = $this->not_reachable_message;
         try {
-            $is_opencast_reachable = OCConfig::checkOpencastAPIConnectivity($config_id);
+            $is_opencast_reachable = OCConfig::checkOpencastAPIConnectivity($config_id, $check_engage_node);
         } catch (\Throwable $th) {
             $message .= ': ' . $th->getMessage();
         }
         if (!$is_opencast_reachable) {
-            echo $message;
+            echo $message . "\n";
         }
         return $is_opencast_reachable;
     }

--- a/lib/Models/REST/Config.php
+++ b/lib/Models/REST/Config.php
@@ -83,4 +83,28 @@ class Config
 
         return $services;
     }
+
+    /**
+     * Checks if the Opencast API is reachable for the given configuration.
+     *
+     * This method performs a basic GET request to the Opencast API base endpoint
+     * using the provided configuration ID. It returns true if the API responds
+     * with a 200 HTTP status code, indicating that the Opencast instance is reachable.
+     *
+     * @param int $config_id The ID of the Opencast configuration to check.
+     * @return bool True if the Opencast API is reachable, false otherwise.
+     */
+    public static function checkOpencastAPIConnectivity(int $config_id): bool
+    {
+        $success = false;
+        $config = ConfigModel::getBaseServerConf($config_id);
+
+        // populate config_id if calling the RestClient directly
+        $config['config_id'] = $config['id'];
+        $oc = new RestClient($config);
+
+        $response = $oc->opencastApi->baseApi->get();
+
+        return ($response['code'] == 200);
+    }
 }

--- a/lib/Models/REST/Config.php
+++ b/lib/Models/REST/Config.php
@@ -92,12 +92,27 @@ class Config
      * with a 200 HTTP status code, indicating that the Opencast instance is reachable.
      *
      * @param int $config_id The ID of the Opencast configuration to check.
+     * @param bool $check_engage_node A flag to determine whether the check should be performed against engage node (e.g play or search endpoint)
      * @return bool True if the Opencast API is reachable, false otherwise.
      */
-    public static function checkOpencastAPIConnectivity(int $config_id): bool
+    public static function checkOpencastAPIConnectivity(int $config_id, bool $check_engage_node = false): bool
     {
         $success = false;
-        $config = ConfigModel::getBaseServerConf($config_id);
+        $config = null;
+        if ($check_engage_node) {
+            $engage_related_service = 'search';
+            $config = ConfigModel::getConfigForService($engage_related_service, $config_id);
+            // Since the endpoint url by default has an ending of service label, we make sure it is removed!
+            if (!empty($config['service_url'])) {
+                $config['service_url'] = rtrim(str_replace($engage_related_service, '', $config['service_url']), '/');
+            }
+        } else {
+            $config = ConfigModel::getBaseServerConf($config_id);
+        }
+
+        if (empty($config)) {
+            return false;
+        }
 
         // populate config_id if calling the RestClient directly
         $config['config_id'] = $config['id'];

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -793,13 +793,18 @@ class Videos extends UPMap
     }
 
     /**
-     * Removes a video from both opencsat and local sides.
+     * Removes a video from both opencast and local sides.
      *
+     * @param ApiEventsClient|null $api_event_client Optional API client instance. If not provided, a new one will be created.
+
      * @return boolean the result of deletion process
      */
-    public function removeVideo()
+    public function removeVideo(ApiEventsClient $api_event_client = null)
     {
-        $api_event_client = ApiEventsClient::getInstance($this->config_id);
+        // Make sure $api_event_client gets its instance if not passed.
+        if ($api_event_client === null) {
+            $api_event_client = ApiEventsClient::getInstance($this->config_id);
+        }
 
         // if the video exists in opencast, make sure it is deleted
         if ($this->episode && $api_event_client->getEpisode($this->episode)) {

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -442,6 +442,10 @@ class Videos extends UPMap
         $where .= " AND trashed = " . $filters->getTrashed();
         $where .= " AND oc_video.token IS NOT NULL";
 
+        if (empty(\Config::get()->OPENCAST_LIST_UNAVAILABLE_VIDEOS)) {
+            $where .= " AND oc_video.available = 1";
+        }
+
         $sql .= $where;
 
         $sql .= ' GROUP BY oc_video.id';

--- a/lib/Providers/OpencastConstants.php
+++ b/lib/Providers/OpencastConstants.php
@@ -91,6 +91,10 @@ return [
                 'name' => "OPENCAST_UPLOAD_INFO_TEXT_BODY",
                 'tag' => 'ui'
             ],
+            [
+                'name' => "OPENCAST_LIST_UNAVAILABLE_VIDEOS",
+                'tag' => 'functions'
+            ],
         ],
     ],
 ];

--- a/migrations/112_add_config_option_toggle_unavailable_videos.php
+++ b/migrations/112_add_config_option_toggle_unavailable_videos.php
@@ -1,0 +1,26 @@
+<?php
+class AddConfigOptionToggleUnavailableVideos extends Migration
+{
+
+
+    public function description()
+    {
+        return 'Create new config option to toggle unavailable videos listing.';
+    }
+
+    public function up()
+    {
+        Config::get()->create('OPENCAST_LIST_UNAVAILABLE_VIDEOS', [
+            'value' => false,
+            'type' => 'boolean',
+            'range' => 'global',
+            'section' => 'opencast',
+            'description' => 'Nicht verfügbare Videos in Videolisten anzeigen?'
+        ]);
+    }
+
+    public function down()
+    {
+        Config::get()->delete('OPENCAST_LIST_UNAVAILABLE_VIDEOS');
+    }
+}


### PR DESCRIPTION
This PR fixes #1374,

Main changes in this PR are:
- Introducing cronjob utils namespace which has a trait for oc conecttion
- A new method: `OCConfig::checkOpencastAPIConnectivity`
- All cronjobs now have a connection checker before processing.
- Video is marked unavailable when they are no longer found in OC.

**NOTE:** It would be very helpful to test all cronjobs and verify that everything works as expected!