### PR TITLE
Make sure workflow update occurs when opencast is reachable

### DIFF
--- a/lib/Models/REST/WorkflowClient.php
+++ b/lib/Models/REST/WorkflowClient.php
@@ -45,11 +45,16 @@ class WorkflowClient extends RestClient
     /**
      * Returns a revised collection of all tagged Workflow definitions
      *
-     * @return array tagged Workflow Instances
+     * @return array|bool tagged Workflow Instances, or false if something goes wrong!
      */
     public function getTaggedWorkflowDefinitions()
     {
         $wf_defs = self::getDefinitions();
+
+        // We break the process if the return result is false, indicating the connection error!
+        if ($wf_defs === false) {
+            return false;
+        }
 
         $tagged_wfs = array();
         if (!empty($wf_defs)) {

--- a/lib/Models/WorkflowConfig.php
+++ b/lib/Models/WorkflowConfig.php
@@ -36,7 +36,7 @@ class WorkflowConfig extends \SimpleORMap
      * Update mapping of used workflows for passed config
      *
      * @param int $config_id
-     * @param Array $workflows
+     * @param Array? $workflows
      *
      * @return void
      */


### PR DESCRIPTION
This PR fixes #1278 and contains the following changes:

- Updated `getTaggedWorkflowDefinitions` to return false on connection errors.
- Improved `updateWorkflowsByConfigId` to handle unresponsive Opencast instances and avoid further processing!

**NOTE**: the most rubost solution to avoid cronjob executions is introduced in https://github.com/elan-ev/studip-opencast-plugin/pull/1387/commits/bb9a171fc74629d580871875dd8599ba5544fedc included in PR https://github.com/elan-ev/studip-opencast-plugin/pull/1387

