### PR TITLE
Quick Fix for errors in OC Player when sharing videos via link

### DIFF
--- a/lib/Routes/Opencast/UserRoles.php
+++ b/lib/Routes/Opencast/UserRoles.php
@@ -53,11 +53,8 @@ class UserRoles extends OpencastController
         if (!empty($share_uuid)) {
             $video_share = VideosShares::findByUuid($share_uuid);
             if (!empty($video_share)) {
-                if ($episode_id_role_access) {
-                    $roles[] = 'ROLE_EPISODE_' . $video_share->video->episode . '_READ';
-                } else {
-                    $roles[] = $video_share->video->episode . '_read';
-                }
+                $roles[] = 'ROLE_EPISODE_' . $video_share->video->episode . '_READ';
+                $roles[] = $video_share->video->episode . '_read';
             } else {
                 throw new Error('Share not found', 404);
             }


### PR DESCRIPTION
The player displays an error (see screenshot) when using share links and the event id based roles in OC. This error message is caused by missing permissions on the series (for more information see the linked issues below). This patch provides an workaround for share links by assigning the old and the new event id role to a share link user.

This patch can be reverted after the linked issues below are solved.

### Related Opencast Issues
- https://github.com/opencast/opencast/issues/6814
- https://github.com/opencast/opencast/issues/6812

### Player Error (Chrome)
![image](https://github.com/user-attachments/assets/1b7dbc8f-9cbc-4262-a6a5-f37f0f299999)

Note: Firefox shows a slightly different error message.