### PR TITLE
Log actions cleanup and update scheduing optimization

### DIFF
--- a/lib/Models/REST/SchedulerClient.php
+++ b/lib/Models/REST/SchedulerClient.php
@@ -22,9 +22,9 @@ class SchedulerClient extends RestClient
 
     /**
      * Deletes an event
-     * 
+     *
      * @param string $event_id the event id
-     * 
+     *
      * @return boolean success or not
      */
     public function deleteEvent($event_id)
@@ -39,7 +39,7 @@ class SchedulerClient extends RestClient
 
     /**
      * Updates an event
-     * 
+     *
      * @param string $event_id the event id
      * @param int $start start of the event
      * @param int $end end of the event
@@ -48,7 +48,7 @@ class SchedulerClient extends RestClient
      * @param string $mediaPackage mediapackage
      * @param string|array $wfproperties workflow properties
      * @param string|array $agentparameters agent params
-     * 
+     *
      * @return boolean success or not
      */
     public function updateEvent($event_id, $start = 0, $end = 0, $agent = '', $users = '', $mediaPackage = '', $wfproperties = '', $agentparameters = '')

--- a/lib/Routes/Schedule/ScheduleBulk.php
+++ b/lib/Routes/Schedule/ScheduleBulk.php
@@ -51,7 +51,7 @@ class ScheduleBulk extends OpencastController
                     $result = ScheduleHelper::deleteEventForSeminar($course_id, $termin_id);
                     break;
                 case 'update':
-                    $result = ScheduleHelper::updateEventForSeminar($course_id, $termin_id);
+                    $result = ScheduleHelper::updateEventForSeminar($course_id, $termin_id, null, null, true, true);
                     break;
             }
             if (!$result) {

--- a/lib/Routes/Schedule/ScheduleUpdate.php
+++ b/lib/Routes/Schedule/ScheduleUpdate.php
@@ -38,7 +38,7 @@ class ScheduleUpdate extends OpencastController
             'text' => _('Die geplante Aufzeichnung konnte nicht aktualisiert werden.')
         ];
 
-        if (ScheduleHelper::updateEventForSeminar($course_id, $termin_id, $start, $end)) {
+        if (ScheduleHelper::updateEventForSeminar($course_id, $termin_id, $start, $end, true, true)) {
             $message = [
                 'type' => 'success',
                 'text' => _('Die geplante Aufzeichnung wurde aktualisiert.')

--- a/migrations/046_add_remove_media.php
+++ b/migrations/046_add_remove_media.php
@@ -2,35 +2,35 @@
 class AddRemoveMedia extends Migration
 {
 
-  static $log_actions = [
-      [
-          'name'        => 'OC_REMOVE_MEDIA',
-          'description' => 'Opencast: Episode geloescht',
-          'template'    => '%user loeschte Episode %info in %sem(%affected)',
-          'active'      => 1
-      ],
-  ];
+    static $log_actions = [
+        [
+            'name'        => 'OC_REMOVE_MEDIA',
+            'description' => 'Opencast: Episode geloescht',
+            'template'    => '%user loeschte Episode %info in %sem(%affected)',
+            'active'      => 1
+        ],
+    ];
 
 
-  function up()
-  {
-      $db = DBManager::get();
-      $query = $db->prepare("INSERT INTO log_actions (action_id, name, description, info_template, active) VALUES (?, ?, ?, ?, ?)");
+    function up()
+    {
+        $db = DBManager::get();
+        $query = $db->prepare("INSERT INTO log_actions (action_id, name, description, info_template, active) VALUES (?, ?, ?, ?, ?)");
 
-      foreach (self::$log_actions as $action) {
-          $query->execute(array(md5($action['name']), $action['name'], $action['description'], $action['template'], $action['active']));
-      }
-  }
+        foreach (self::$log_actions as $action) {
+            $query->execute(array(md5($action['name']), $action['name'], $action['description'], $action['template'], $action['active']));
+        }
+    }
 
-  function down()
-  {
-      $db = DBManager::get();
-      $query = $db->prepare("DELETE FROM log_actions WHERE action_id = ?");
-      $query2 = $db->prepare("DELETE FROM log_events WHERE action_id = ?");
+    function down()
+    {
+        $db = DBManager::get();
+        $query = $db->prepare("DELETE FROM log_actions WHERE action_id = ?");
+        $query2 = $db->prepare("DELETE FROM log_events WHERE action_id = ?");
 
-      foreach (self::$log_actions as $action) {
-          $query->execute(array(md5($action['name'])));
-          $query2->execute(array(md5($action['name'])));
-      }
-  }
+        foreach (self::$log_actions as $action) {
+            $query->execute(array(md5($action['name'])));
+            $query2->execute(array(md5($action['name'])));
+        }
+    }
 }

--- a/migrations/113_remove_log_actions.php
+++ b/migrations/113_remove_log_actions.php
@@ -1,0 +1,72 @@
+<?php
+class RemoveLogActions extends Migration
+{
+    const PLUGINCLASSNAME = 'OpencastV3';
+
+    private $log_actions = [
+        [
+            'name'        => 'OC_CHANGE_EPISODE_VISIBILITY',
+            'description' => 'Opencast: Sichtbarkeit einer Episode geandert',
+            'template'    => '%user aendert Sichtbarkeit der Aufzeichnung %affected in %sem(%coaffected)',
+        ],
+        [
+            'name'        => 'OC_CHANGE_TAB_VISIBILITY',
+            'description' => 'Opencast:  Sichtbarkeit des Kursreiters geaendert',
+            'template'    => '%user aendert Sichtbarkeit des Kursreiters in %sem(%affected)',
+        ],
+        [
+            'name'        => 'OC_CREATE_SERIES',
+            'description' => 'Opencast: Anlegen einer Aufzeichnungsserie',
+            'template'    => '%user legt neue Aufzeichnungsserie in %sem(%affected) an',
+        ],
+        [
+            'name'        => 'OC_CONNECT_SERIES',
+            'description' => 'Opencast: Verknuepfung einer Aufzeichnungsserie',
+            'template'    => '%user verknuepft vorhandene Aufzeichnungsserie %affected in %sem(%coaffected) an',
+        ],
+        [
+            'name'        => 'OC_REMOVE_CONNECTED_SERIES',
+            'description' => 'Opencast: Aufheben einer Aufzeichnungsserienverknuepfung',
+            'template'    => '%user loescht die Verbindung zur Aufzeichnungsserie %affected in %sem(%coaffected) an',
+        ],
+        [
+            'name'        => 'OC_UPLOAD_MEDIA',
+            'description' => 'Opencast: Upload einer Datei in einer Aufzeichnungsserie',
+            'template'    => '%user laedt eine Datei mit der WorkflowID %affected in %sem(%coaffected) hoch',
+        ],
+        [
+            'name'        => 'OC_REMOVE_MEDIA',
+            'description' => 'Opencast: Episode geloescht',
+            'template'    => '%user loeschte Episode %info in %sem(%affected)',
+        ],
+        [
+            'name'        => 'OC_TOS',
+            'description' => 'Opencast: TOS akzeptiert/abgelehnt',
+            'template'    => '%user hat TOS %info in %sem(%affected)',
+        ],
+    ];
+
+    public function description()
+    {
+        return 'Remove unwanted log actions';
+    }
+
+    public function up()
+    {
+        foreach ($this->log_actions as $log_action) {
+            StudipLog::unregisterAction($log_action['name']);
+        }
+    }
+
+    public function down()
+    {
+        foreach ($this->log_actions as $log_action) {
+            StudipLog::registerActionPlugin(
+                $log_action['name'],
+                $log_action['description'],
+                $log_action['template'],
+                self::PLUGINCLASSNAME
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #1392,
It contains:
- Refactoring update scheduling method to improve clarity and add force update option:
   - we make sure the update against OC occurs only when there is a change unless the optional flag forces it!
- Removing unwanted log actions via migration No. `113`