### PR TITLE
Event ACL update correct in playlist section

### DIFF
--- a/lib/Models/Playlists.php
+++ b/lib/Models/Playlists.php
@@ -729,8 +729,6 @@ class Playlists extends UPMap
                     'service_entry_id'  => $entry->id ?? null,
                     'available'         => false                      // this video is not available in courses yet
                 ]);
-
-                Videos::checkEventACL(null, null, $db_video);
             }
 
             if (!is_null($playlist_video)) {
@@ -738,6 +736,8 @@ class Playlists extends UPMap
                 $playlist_video->service_entry_id = $entry->id ?? null;
                 $playlist_video->order = $key;
                 $playlist_video->store();
+
+                Videos::checkEventACL(null, null, $db_video); // always update video acl!
             }
         }
     }

--- a/lib/Routes/Playlist/PlaylistAddVideos.php
+++ b/lib/Routes/Playlist/PlaylistAddVideos.php
@@ -47,6 +47,9 @@ class PlaylistAddVideos extends OpencastController
                     'video_id'    => $video->id
                 ]);
 
+                // Update the event acl first!
+                Videos::checkEventACL(null, null, $video);
+
                 try {
                     $playlist->videos[] = $plvideo;
                 } catch (\InvalidArgumentException $e) {
@@ -54,8 +57,6 @@ class PlaylistAddVideos extends OpencastController
             }
 
             $playlist->videos->store();
-
-            Videos::checkEventACL(null, null, $video);
 
             return $response->withStatus(204);
         }

--- a/lib/Routes/Playlist/PlaylistRemoveVideos.php
+++ b/lib/Routes/Playlist/PlaylistRemoveVideos.php
@@ -48,9 +48,10 @@ class PlaylistRemoveVideos extends OpencastController
                     ]
                 );
                 $plvideo->delete();
-            }
 
-            Videos::checkEventACL(null, null, $video);
+                // Update the event acl!
+                Videos::checkEventACL(null, null, $video);
+            }
 
             return $response->withStatus(204);
         }


### PR DESCRIPTION
This PR fixes #1384,

Trying to correct the event ACL update when adding or removing video to a playlist which also contains the coresponsing course's ACL.

