### PR TITLE
Enhance ACL synchronization info and handle missing video records

### DIFF
--- a/cronjobs/opencast_sync_acls.php
+++ b/cronjobs/opencast_sync_acls.php
@@ -72,15 +72,23 @@ class OpencastSyncAcls extends CronJob
                         // check if video exists in Stud.IP
                         $video = Videos::findByEpisode($event->identifier);
 
+                        // In case, the video is not yet discovered by the discovery worker!
+                        if (empty($video)) {
+                            echo " [Skipped] No local video record found, skipping: {$event->identifier}\n";
+                            continue;
+                        }
+
                         $video->created = date('Y-m-d H:i:s', strtotime($event->created));
                         $video->store();
 
                         if ($video->config_id != $config->id) {
-                            echo 'config id mismatch for Video with id: '. $video->id .", $config->id <> {$video->config_id}\n";
+                            echo ' [Skipped] config id mismatch for Video with id: '. $video->id .", $config->id <> {$video->config_id}\n";
                             continue;
                         }
 
                         Videos::checkEventACL(null, $event, $video);
+
+                        echo " ACL sync successful for Video ID {$video->id} (Event ID: {$event->identifier}).\n";
                     }
                 }
             } while (!empty($oc_events));


### PR DESCRIPTION
This PR fixes #1397,

it skips the missing video record during ACL sync worker to ensure seamless processing.
enhance info/loggin of the cronjob.