### PR TITLE
Rework scheduling mechanism

### DIFF
--- a/lib/Models/ScheduleHelper.php
+++ b/lib/Models/ScheduleHelper.php
@@ -599,11 +599,21 @@ class ScheduleHelper
             return false;
         }
 
-        $scheduler_client = SchedulerClient::getInstance($config_id);
+        // In order to delete the scheduled recording from Opencast, we ensure that the event already exists!
+        // this is important to avoid breaking search index.
+        $api_event_client = ApiEventsClient::getInstance($config_id);
+        $oc_event = $api_event_client->getEpisode($event_id);
+        $event_exists = !empty($oc_event) && $oc_event->status == 'EVENTS.EVENTS.STATUS.SCHEDULED';
 
-        $result = $scheduler_client->deleteEvent($event_id);
+        $oc_deleted_result = false;
+        if ($event_exists) {
+            $scheduler_client = SchedulerClient::getInstance($config_id);
+            $oc_deleted_result = $scheduler_client->deleteEvent($event_id);
+        }
 
-        if ($result) {
+        // In case of successfully deleted the event in opencast or the event could not be found,
+        // we need to remove the records in SOCP as well!
+        if ($oc_deleted_result || (!$oc_deleted_result && !$event_exists)) {
             ScheduledRecordings::unscheduleRecording($event_id, $resource_id, $termin_id);
             // Remove the livestream video here!
             if ($is_livestream) {
@@ -703,6 +713,16 @@ class ScheduleHelper
             $workflow_id = $is_livestream ? $resource_obj['livestream_workflow_id'] : $resource_obj['workflow_id'];
             $scheduled_recording_obj->workflow_id = $workflow_id;
             $scheduled_recording_obj->store();
+        }
+
+        // In order to update the scheduled recording in Opencast, we ensure that the event already exists!
+        // this is important to avoid breaking search index.
+        $api_event_client = ApiEventsClient::getInstance($resource_obj['config_id']);
+        $oc_event = $api_event_client->getEpisode($event_id);
+        $event_exists = !empty($oc_event) && $oc_event->status == 'EVENTS.EVENTS.STATUS.SCHEDULED';
+
+        if (!$event_exists) {
+            return false;
         }
 
         $metadata = self::createEventMetadata($course_id, $resource_id, $resource_obj['config_id'], $termin_id, $event_id, $is_livestream);
@@ -979,24 +999,40 @@ class ScheduleHelper
         // We take the current resource obj to use its data for deleteEventForSeminar,
         // to make sure that server config id is correct!
         $ex_resource_obj = Resources::findByResource_id($resource_id);
+
+        // We record the config (server) change.
+        $server_ca_has_been_changed = (int) $ex_resource_obj['config_id'] !== (int) $config_id;
+
         // We Update the resource first.
         $success = Resources::setResource($resource_id, $config_id, $capture_agent, $workflow_id, $livestream_workflow_id);
         // If is updated.
-        /*
         if ($success) {
-            // We update current scheduled events that uses this resource.
+            // We loop through current recorded with this recourse to update or delete them!
             if ($scheduled_recordings = ScheduledRecordings::getScheduleRecordingList($resource_id)) {
                 foreach ($scheduled_recordings as $recording) {
-                    // We try to update the those record as well.
-                    $updated = self::updateEventForSeminar($recording['seminar_id'], $recording['date_id'], null, null, true);
-                    // If update fails, we remove them!
-                    if (!$updated && $ex_resource_obj) {
-                        self::deleteEventForSeminar($recording['seminar_id'], $recording['date_id'], $ex_resource_obj['config_id']);
+                    // In case the config (sever) has been changed, we remove the recording.
+                    if ($server_ca_has_been_changed) {
+                        self::deleteEventForSeminar(
+                            $recording['seminar_id'],
+                            $recording['date_id'],
+                            $ex_resource_obj['config_id']
+                        );
+                    } else {
+                        // Otherwise, we try to update the recording.
+                        $updated = self::updateEventForSeminar($recording['seminar_id'], $recording['date_id'], null, null, true);
+                        // If update fails, we remove them!
+                        if (!$updated && $ex_resource_obj) {
+                            self::deleteEventForSeminar(
+                                $recording['seminar_id'],
+                                $recording['date_id'],
+                                $ex_resource_obj['config_id']
+                            );
+                        }
                     }
+
                 }
             }
         }
-        */
         return $success;
     }
 
@@ -1014,7 +1050,7 @@ class ScheduleHelper
         $ex_resource_obj = Resources::findByResource_id($resource_id);
         // Then we delete the resource.
         $success = Resources::removeResource($resource_id);
-        // If the deletion succeed, then we perform the deleting of the scheduled recordings.
+        // If the deletion succeed, then we perform the deleting of the scheduled recordings in the future!
         if ($success) {
             $scheduled_recordings = ScheduledRecordings::getScheduleRecordingList($resource_id);
             if (!empty($scheduled_recordings) && !empty($ex_resource_obj)) {
@@ -1119,8 +1155,8 @@ class ScheduleHelper
                 'description'   => $event->description,
                 'duration'      => $event->duration,
                 'state'         => 'running',
-		        'created'       => date('Y-m-d H:i:s', strtotime($event->created)),
-		        'presenters'    => $event->creator,
+                'created'       => date('Y-m-d H:i:s', strtotime($event->created)),
+                'presenters'    => $event->creator,
                 'available'     => true,
                 'publication'   => $publication,
                 'is_livestream' => true,

--- a/lib/Models/ScheduledRecordings.php
+++ b/lib/Models/ScheduledRecordings.php
@@ -101,7 +101,7 @@ class ScheduledRecordings extends \SimpleORMap
 
     /**
      * Gets the list of schedule recording based on the parameters passed
-     * It will by default get the records in the future, unless $include_old_records is set!
+     * It will by default get the records in the future.
      *
      * @param string $resource_id id of resource
      * @param string $seminar_id id of course
@@ -116,8 +116,7 @@ class ScheduledRecordings extends \SimpleORMap
         $resource_id = null,
         $seminar_id = null,
         $status = '',
-        $is_livestream = null,
-        $include_old_records = false)
+        $is_livestream = null)
     {
         $where_array = [];
         $params = [];
@@ -138,11 +137,11 @@ class ScheduledRecordings extends \SimpleORMap
             $where_array[] = "is_livestream = ?";
             $params[] = $is_livestream;
         }
-        // Always get the records in future, unless intentionally requested otherwise via $include_old_records
-        if (!$include_old_records) {
-            $where_array[] = "start >= ?";
-            $params[] = time();
-        }
+        
+        // Always retrieve only future records
+        $where_array[] = "start >= ?";
+        $params[] = time();
+
         if (!empty($where_array)) {
             return self::findBySQL(implode(' AND ', $where_array), $params);
         }

--- a/lib/Models/ScheduledRecordings.php
+++ b/lib/Models/ScheduledRecordings.php
@@ -101,15 +101,23 @@ class ScheduledRecordings extends \SimpleORMap
 
     /**
      * Gets the list of schedule recording based on the parameters passed
+     * It will by default get the records in the future, unless $include_old_records is set!
      *
      * @param string $resource_id id of resource
      * @param string $seminar_id id of course
      * @param string $status the status of the record
      * @param bool|null $is_livestream the livestream flag of the record
+     * @param bool $include_old_records If true, includes all records regardless of their date;
+     *                                  if false, only future (upcoming) records are returned.
      *
      * @return object|bool
      */
-    public static function getScheduleRecordingList($resource_id = null, $seminar_id = null, $status = '', $is_livestream = null)
+    public static function getScheduleRecordingList(
+        $resource_id = null,
+        $seminar_id = null,
+        $status = '',
+        $is_livestream = null,
+        $include_old_records = false)
     {
         $where_array = [];
         $params = [];
@@ -129,6 +137,11 @@ class ScheduledRecordings extends \SimpleORMap
             $is_livestream = (bool) $is_livestream ? 1 : 0;
             $where_array[] = "is_livestream = ?";
             $params[] = $is_livestream;
+        }
+        // Always get the records in future, unless intentionally requested otherwise via $include_old_records
+        if (!$include_old_records) {
+            $where_array[] = "start >= ?";
+            $params[] = time();
         }
         if (!empty($where_array)) {
             return self::findBySQL(implode(' AND ', $where_array), $params);

--- a/lib/Routes/Config/ConfigUpdate.php
+++ b/lib/Routes/Config/ConfigUpdate.php
@@ -48,7 +48,7 @@ class ConfigUpdate extends OpencastController
                         ];
                     }
                 } else {
-                    // ScheduleHelper::deleteResource($resource['id']);
+                    ScheduleHelper::deleteResource($resource['id']);
                 }
             }
         }

--- a/vueapp/components/Config/SchedulingEditModal.vue
+++ b/vueapp/components/Config/SchedulingEditModal.vue
@@ -1,0 +1,265 @@
+<template>
+    <div>
+        <StudipDialog
+            :title="$gettext('Ressource bearbeiten')"
+            :confirmText="$gettext('Akzeptieren')"
+            :confirmClass="'accept'"
+            :closeText="$gettext('Abbrechen')"
+            :closeClass="'cancel'"
+            height="415"
+            width="500"
+            @confirm="acceptChanges"
+            @close="close"
+        >
+            <template v-slot:dialogContent>
+                <form class="default" @submit="acceptChanges" ref="formRef">
+                    <fieldset>
+                        <label>
+                            <span>{{ $gettext('Raum') }}</span>
+                            <input type="text" disabled :value="editing_resource.name"/>
+                        </label>
+
+                        <label>
+                            <span class="required">
+                                {{ $gettext('Capture Agent') }}
+                            </span>
+
+                            <select @change="assignCA($event)" required>
+                                <option value="" disabled :selected="!editing_resource?.capture_agent">
+                                    {{ $gettext('Bitte wählen Sie einen CA.') }}
+                                </option>
+                                <template v-for="(ca_obj, index) in filtered_capture_agents" :key="index">
+                                    <optgroup style="font-weight:bold;" :label="`Server #${ca_obj.id}`">
+                                        <option v-for="(capture_agent, calindex) in ca_obj.list"
+                                            :key="calindex"
+                                            :value="capture_agent.list_id"
+                                            :disabled="capture_agent?.in_use && `${ca_obj.id}_${editing_resource.capture_agent}` !== capture_agent.list_id"
+                                            :selected="`${ca_obj.id}_${editing_resource.capture_agent}` === capture_agent.list_id && capture_agent?.in_use"
+                                        >
+                                            {{ capture_agent.name }}
+                                        </option>
+                                    </optgroup>
+                                </template>
+                            </select>
+                        </label>
+
+                        <label>
+                            <span>
+                                {{ $gettext('Workflow') }}
+                            </span>
+
+                            <select v-model="editing_resource.workflow_id">
+                                <option value="" disabled :selected="!editing_resource?.workflow_id">
+                                    {{ $gettext('Bitte wählen Sie einen Workflow aus.') }}
+                                </option>
+                                <option v-for="workflow in compiledWDList(editing_resource)"
+                                    :key="workflow.id"
+                                    :value="workflow.id"
+                                >
+                                    {{ workflow.title }}
+                                </option>
+                            </select>
+                        </label>
+
+                        <label>
+                            <span>
+                                {{ $gettext('Livestream Workflow') }}
+                            </span>
+
+                            <select v-model="editing_resource.livestream_workflow_id">
+                                <option value="" disabled :selected="!editing_resource?.livestream_workflow_id">
+                                    {{ $gettext('Bitte wählen Sie einen Workflow aus.') }}
+                                </option>
+                                <option v-for="workflow in compiledWDList(editing_resource)"
+                                    :key="workflow.id"
+                                    :value="workflow.id"
+                                >
+                                    {{ workflow.title }}
+                                </option>
+                            </select>
+                        </label>
+                    </fieldset>
+                </form>
+            </template>
+        </StudipDialog>
+    </div>
+</template>
+
+<script setup>
+import StudipDialog from '@studip/StudipDialog';
+import { useStore } from "vuex";
+import { useGettext } from 'vue3-gettext';
+
+import { ref, defineComponent, defineEmits, defineProps, computed } from 'vue';
+
+const { $gettext } = useGettext();
+const store = useStore();
+
+defineOptions({ name: 'SchedulingEditModal' });
+
+// const props = defineProps({
+//     editing_resource: Object,
+//     config_list: Object,
+// });
+
+const emit = defineEmits(['done', 'cancel']);
+
+defineComponent({
+    StudipDialog
+});
+
+const formRef = ref();
+
+const config_list = computed(() => {
+    return store.getters.config_list;
+});
+
+const editing_resource = computed(() => {
+    return store.getters.schedulingEditResourceObj;
+});
+
+const resources = computed(() => {
+    let resources = [];
+    if (config_list.value?.scheduling?.resources) {
+        resources = config_list.value.scheduling.resources;
+    }
+    return resources;
+});
+
+const editing_resource_index = computed(() => {
+    return resources.value.findIndex(rs => rs.id === editing_resource.value.id);
+});
+
+const current_resource = computed(() => {
+    return resources.value?.[editing_resource_index.value];
+});
+
+const capture_agents = computed(() => {
+    let capture_agents = [];
+    if (config_list.value?.scheduling?.capture_agents) {
+        capture_agents = config_list.value.scheduling.capture_agents;
+    }
+    return capture_agents;
+});
+
+const filtered_capture_agents = computed(() => {
+    let filtered_capture_agents = [];
+    if (capture_agents.value) {
+        let configs = capture_agents.value.map(ca => {return ca.config_id;})
+                        .filter((item, i, ar) => ar.indexOf(item) === i);
+        for (let ci = 0; ci < configs.length; ci++) {
+            let ca_cat = capture_agents.value.filter(ca => ca.config_id == configs[ci]);
+            ca_cat.map(ca => ca.list_id = `${ca.config_id}_${ca.name}`);
+            if (ca_cat.length) {
+                filtered_capture_agents.push({
+                    id: configs[ci],
+                    list: ca_cat
+                });
+            }
+        }
+    }
+    return filtered_capture_agents;
+});
+
+const workflow_definitions = computed(() => {
+    let workflow_definitions = [];
+    if (config_list.value?.scheduling?.workflow_definitions) {
+        workflow_definitions = config_list.value?.scheduling?.workflow_definitions;
+    }
+    return workflow_definitions;
+});
+
+const compiledWDList = (resource_obj) => {
+    let workflows = [];
+    let capture_agent_obj = capture_agents.value.filter(
+        ca => ca.name == resource_obj.capture_agent && ca.config_id == resource_obj.config_id
+    );
+    if (capture_agent_obj.length) {
+        let config_id = capture_agent_obj[0].config_id;
+        workflows = workflow_definitions.value.filter(wd => wd.config_id == config_id);
+    }
+    return workflows;
+};
+
+const acceptChanges = () => {
+    if (!formRef.value.reportValidity()) {
+        return false;
+    }
+
+    // If there is no change, we close the modal!
+    if (JSON.stringify(editing_resource.value) === JSON.stringify(current_resource.value)) {
+        store.dispatch('closeSchedulingEditModal');
+        return;
+    }
+
+    // As long as the changes are within the same config (server), it is possible to change CA and WFs
+    if (parseInt(editing_resource.value.config_id, 10) === parseInt(current_resource.value.config_id, 10)
+    ) {
+        applyEditChanges();
+        return;
+    }
+
+    // In case we hit here, that means capture agent and config (server) has been changed, so we open the confirmation modal.
+    let confirmData = {
+        title: $gettext('Änderungen bestätigen'),
+        text: $gettext('Der Aufnahmeagent wurde geändert. Dadurch werden alle zukünftig zugewiesenen geplanten Aufnahmen für diesen Raum und diesen Aufnahmeagenten entfernt! Möchten Sie fortfahren?'),
+        confirm: () => {
+            applyEditChanges();
+        },
+        width: 545,
+    }
+
+    store.dispatch('openConfirmationModal', confirmData);
+    store.dispatch('closeSchedulingEditModal', false);
+    return;
+};
+
+const applyEditChanges = () => {
+    if (!current_resource.value || !editing_resource.value) {
+        // TODO: print the error via addMessage modal version.
+        return;
+    }
+    // Make CA not in use!
+    toggleCAOccupation(current_resource.value.capture_agent, current_resource.value.config_id, false);
+    // Replace current resource with editing resource.
+    Object.assign(current_resource.value, editing_resource.value);
+    // Make CA in use!
+    toggleCAOccupation(current_resource.value.capture_agent, current_resource.value.config_id, true);
+
+    store.dispatch('toggleSchedulingUnsavedChanges', true);
+    store.dispatch('closeSchedulingEditModal');
+    store.dispatch('closeConfirmationModal');
+}
+
+const toggleCAOccupation = (capture_agent, config_id, status = true) => {
+    let ca_index = capture_agents.value.findIndex(ca => ca.name == capture_agent && ca.config_id == config_id);
+    if (ca_index != -1) {
+        capture_agents.value[ca_index]['in_use'] = status;
+    }
+};
+
+const assignCA = (event) => {
+    event.preventDefault();
+    let value = event.target.value;
+    let selected_ca_arr = value.split('_');
+    if (selected_ca_arr.length == 2) {
+        let selected_config_id = selected_ca_arr[0];
+        let selected_ca = selected_ca_arr[1];
+        let capture_agent_obj = capture_agents.value.filter(
+            ca => ca.name == selected_ca && ca.config_id == selected_config_id
+        );
+        if (capture_agent_obj.length) {
+            let current_ca = editing_resource.value.capture_agent;
+            let current_config_id = editing_resource.value.config_id;
+            toggleCAOccupation(current_ca, current_config_id, false);
+            editing_resource.value.capture_agent = selected_ca;
+            editing_resource.value.config_id = selected_config_id;
+            toggleCAOccupation(selected_ca, selected_config_id, true);
+        }
+    }
+};
+
+const close = () => {
+    store.dispatch('closeSchedulingEditModal');
+};
+</script>

--- a/vueapp/store/config.module.js
+++ b/vueapp/store/config.module.js
@@ -15,7 +15,12 @@ const initialState = {
             'ssl_ignore_cert_errors': null
         }
     },
-    course_config: null
+    course_config: null,
+    confirmation_modal_shown: false,
+    confirmation_modal_obj: null, // || {title: '',text: '',confirm: undefined, width: ?, height: ?}
+    scheduling_has_unsaved_changes: false,
+    scheduling_edit_modal_shown: false,
+    scheduling_edit_resource_obj: null,
 };
 
 const getters = {
@@ -41,6 +46,29 @@ const getters = {
         } else {
             return false;
         }
+    },
+
+    confirmationModalObj(state) {
+        return state.confirmation_modal_obj;
+    },
+
+    shouldConfirmationModalBeVisible(state) {
+        return state.confirmation_modal_shown !== false
+            && state.confirmation_modal_obj?.title != ''
+            && state.confirmation_modal_obj?.text != ''
+            && state.confirmation_modal_obj?.confirm != undefined;
+    },
+
+    schedulingHasUnsavedChanges(state) {
+        return state.scheduling_has_unsaved_changes;
+    },
+
+    schedulingEditResourceObj(state) {
+        return state.scheduling_edit_resource_obj;
+    },
+
+    shouldSchedulingEditModalBeVisible(state) {
+        return state.scheduling_edit_modal_shown !== false;
     }
 };
 
@@ -116,7 +144,35 @@ export const actions = {
 
     configSetActivation(context, params) {
         return ApiService.put('config/' + params.id + '/' + (params.active ? 'activate' : 'deactivate'));
-    }
+    },
+
+    openConfirmationModal(context, data) {
+        context.commit('setConfirmationModalObj', data);
+        context.commit('setConfirmationModalShown', true);
+    },
+
+    closeConfirmationModal(context, empty_obj = true) {
+        context.commit('setConfirmationModalShown', false);
+        if (empty_obj) {
+            context.commit('setConfirmationModalObj', null);
+        }
+    },
+
+    toggleSchedulingUnsavedChanges(context, status) {
+        context.commit('setSchedulingUnsavedChanges', status ? true : false);
+    },
+
+    openSchedulingEditModal(context, data) {
+        context.commit('setSchedulingEditResourceObj', data);
+        context.commit('setSchedulingEditModalShown', true);
+    },
+
+    closeSchedulingEditModal(context, empty_obj = true) {
+        context.commit('setSchedulingEditModalShown', false);
+        if (empty_obj) {
+            context.commit('setSchedulingEditResourceObj', null);
+        }
+    },
 };
 
 /* eslint no-param-reassign: ["error", { "props": false }] */
@@ -139,12 +195,32 @@ export const mutations = {
         }
 
         state.config = data;
+    },
+
+    setConfirmationModalObj(state, data) {
+        state.confirmation_modal_obj = data;
+    },
+
+    setConfirmationModalShown(state, status) {
+        state.confirmation_modal_shown = status;
+    },
+
+    setSchedulingUnsavedChanges(state, status) {
+        state.scheduling_has_unsaved_changes = status;
+    },
+
+    setSchedulingEditResourceObj(state, data) {
+        state.scheduling_edit_resource_obj = data;
+    },
+
+    setSchedulingEditModalShown(state, status) {
+        state.scheduling_edit_modal_shown = status;
     }
 };
 
 export default {
-  state,
-  actions,
-  mutations,
-  getters
+    state,
+    actions,
+    mutations,
+    getters
 };


### PR DESCRIPTION
This PR fixes #1300,

Enhance Opencast scheduling functionality with improved event validation and modal management for editing

- Added checks to ensure events exist before every deletion or updating scheduled event in opencast to avoid search index conflicts.
- Introduced a new SchedulingEditModal for editing resources with confirmation prompts.
- Updated SchedulingOptions to handle unsaved changes and resource editing.
- Enhanced state management in Vuex for scheduling-related modals and unsaved changes.