### PR TITLE
Send all capture.device.names when scheduling

### DIFF
--- a/classes/OCRestClient/CaptureAgentAdminClient.php
+++ b/classes/OCRestClient/CaptureAgentAdminClient.php
@@ -33,7 +33,12 @@ class CaptureAgentAdminClient extends OCRestClient
         $service_url = "/agents/" . $agent_name . "/capabilities.json";
         if ($agent = $this->getJSON($service_url)) {
             $x = 'properties-response';
-            return $agent->$x->properties->item;
+            $items = $agent->$x->properties->item;
+            // https://github.com/orgs/opencast/discussions/6988
+            if (isset($items) && is_object($items) && !is_array($items)) {
+                $items = [$items];
+            }
+            return $items;
         } else {
             return false;
         }


### PR DESCRIPTION
set capture.device.names properly if there is only one
properties-response.properties.item

Resolves #1412