### PR TITLE
Warn if memory limit is to low for cronjob

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,10 @@ For this plugin to work, you need:
 - Stud.IP >= Version 5.1
 - Opencast >= Version 13.1
 
+## PHP
+
+Make sure the memory limit for your Stud.IP cronjobs is at least 256M, or the cronjobs for this plugin might fail.
+
 ## Configure Opencast
 
 Refer to the [Opencast documentation](https://docs.opencast.org) for instructions on how to configure your version of the Opencast system.

--- a/cronjobs/opencast_discover_videos.php
+++ b/cronjobs/opencast_discover_videos.php
@@ -35,6 +35,10 @@ class OpencastDiscoverVideos extends CronJob
 
     public function execute($last_result, $parameters = array())
     {
+        if (!self::isMemoryLimitAtLeast('256M')) {
+            echo '[WARNING] PHP memory_limit is below 256M, the cronjob might fail!' . "\n";
+        }
+
         /*
             - Neue Videos in OC identifizieren (die Stud.IP noch nicht kennt)
             - Eintragen der Videos und setzen der Rechte (Queue)
@@ -312,5 +316,24 @@ class OpencastDiscoverVideos extends CronJob
         // send out Notifications for video discovery plugins to react
         NotificationCenter::postNotification('OpencastCourseSync', $event, $video);
         NotificationCenter::postNotification('OpencastVideoSync', $event, $video);
+    }
+
+    private static function isMemoryLimitAtLeast($target_limit)
+    {
+        if (!function_exists('ini_parse_quantity')) {
+            return true;
+        }
+
+        $memory_limit = ini_get('memory_limit');
+        if ($memory_limit === false || $memory_limit === '') {
+            return false;
+        }
+
+        $current_bytes = ini_parse_quantity($memory_limit);
+        if ($current_bytes < 0) {
+            return true;
+        }
+
+        return $current_bytes >= ini_parse_quantity($target_limit);
     }
 }


### PR DESCRIPTION
fixes #1447 

- Warn if memory limit is to low, but only for php version 8.2 to avoid code bloat
- Update installation documentation