### PR TITLE
fixing multiconnected series and adding republish on changed episode ACL (v2)

### DIFF
--- a/classes/lti/OpencastLTI.php
+++ b/classes/lti/OpencastLTI.php
@@ -362,6 +362,12 @@ class OpencastLTI
             }
             if ($oc_acl <> $acl->toArray()) {
                 $client->setACL($target_id, $acl);
+
+                // republish episode to apply new ACLs
+                if ($target_type == 'episode') {
+                     $workflow_api_client = \ApiWorkflowsClient::create($courses[0]);
+                     $workflow_api_client->republish($target_id);
+                }
             }
         }
     }

--- a/models/OCCourseModel.class.php
+++ b/models/OCCourseModel.class.php
@@ -64,32 +64,31 @@ class OCCourseModel
         $this->seriesMetadata = $seriesMetadata;
     }
 
-
     public function getEpisodes()
     {
-        static $ordered_episodes;
+        static $ordered_episodes = [];
 
-        if (empty($ordered_episodes)) {
+        $course_id = $this->getCourseID();
+
+        if (!isset($ordered_episodes[$course_id])) {
+
             if ($this->getSeriesID()) {
-                $api_events = ApiEventsClient::create($this->getCourseID());
-                $series     = $api_events->getBySeries($this->getSeriesID(), $this->getCourseID());
+                $api_events = ApiEventsClient::create($course_id);
+                $series     = $api_events->getBySeries($this->getSeriesID(), $course_id);
 
-                $stored_episodes  = OCModel::getCoursePositions($this->getCourseID());
-                $ordered_episodes = [];
+                $stored_episodes = OCModel::getCoursePositions($course_id);
 
-                //check if series' episodes is already stored in studip
                 if (!empty($series)) {
-                    // add additional episode metadata from opencast
-                    $ordered_episodes = $this->episodeComparison($stored_episodes, $series);
+                    $ordered_episodes[$course_id] = $this->episodeComparison($stored_episodes, $series);
+                } else {
+                    $ordered_episodes[$course_id] = [];
                 }
-
-                return $ordered_episodes;
             } else {
-                return false;
+                return [];
             }
         }
 
-        return $ordered_episodes;
+        return $ordered_episodes[$course_id];
     }
 
     private function episodeComparison($stored_episodes, $oc_episodes)


### PR DESCRIPTION
During ACL generation for an episode, a shared static variable is reused to return the course visibility, resulting in an incorrect ACL for the episode.  
The recall of `OCCourseModel` does not reset this static variable, causing stale values to persist.  

Additionally, no republish event is triggered when the episode ACL differs from the expected ACL.  