### PR TITLE
Fixes cronjob issues in case where ACLs are sorted differently

### DIFF
--- a/lib/Models/Helpers.php
+++ b/lib/Models/Helpers.php
@@ -14,6 +14,7 @@ use Opencast\Models\REST\ApiWorkflowsClient;
 class Helpers
 {
     const RECORDED_SERIES_ID_CACHE_ID = 'OpencastV3/series/recorded_series_ids';
+    const ACL_STRING_SEPARATOR = '**';
 
     static function getConfigurationstate()
     {
@@ -336,6 +337,26 @@ class Helpers
 
         return $comp_a <=> $comp_b;
 
+    }
+
+    /**
+     * It generates an associative unique array out of raw acls array, which now has unique string keys made out of the values.
+     * IT also makes sure that the order of the acl values action, allow, role are always sorted ascending!
+     * @param array $raw_acls
+     * @return array associative unique acls array
+     */
+    public static function generateAssociativeUniqueAcls(array $raw_acls): array
+    {
+        $assoc_acls = [];
+        foreach ($raw_acls as $acl) {
+            $generated_acl_id = ($acl['allow'] ? '1' : '0') . self::ACL_STRING_SEPARATOR .
+                                $acl['role'] . self::ACL_STRING_SEPARATOR .
+                                $acl['action'];
+            ksort($acl);
+            $assoc_acls[$generated_acl_id] = $acl;
+        }
+
+        return $assoc_acls;
     }
 
     /**

--- a/lib/Models/Videos.php
+++ b/lib/Models/Videos.php
@@ -992,13 +992,39 @@ class Videos extends UPMap
 
         $oc_acls = Helpers::filterACLs($current_acl, $acl);
 
-        if ($acl <> $oc_acls['studip']) {
+        if (!$this->compareAclsRaw($acl, $oc_acls['studip'])) {
             $new_acl = array_merge($oc_acls['other'], $acl);
 
             return $api_client->setACL($this->episode, $new_acl);
         }
 
         return false;
+    }
+
+    /**
+     * This functions compares two ACLs. Before the comparisson
+     * it creates unique keys for each array element, removes duplicates
+     * and sorts the arrays.
+     * 
+     * @param object $base
+     * @param object $target
+     */
+    private function compareAclsRaw($base, $target) {
+
+        // creates unique keys for the array elements and removes duplicates
+        $base = Helpers::generateAssociativeUniqueAcls($base);
+        $target = Helpers::generateAssociativeUniqueAcls($target);
+
+        if (count($base) !== count($target)) {
+            return false;
+        }
+
+        // Now that arrays have unique keys based on their values,
+        // so we can make sure that ksort does its job 100%.
+        ksort($base);
+        ksort($target);
+
+        return $base == $target;
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug, where the "discover videos" cronjob doesn't work properly. The problem occurs, when the ACLs of Opencast doesn't match the saved ACLs of Stud.IP in regards of sorting. This PR, originally created by @ferishili, adds a helper function, that adds unique keys to the ACL arrays, so they can be sorted before before comparison.

The origin of the problem couldn't be determined by 100%, but it occurred after an Update of Opencast from 17 to 19. The chances are high, that it has something to do with a script, that has to be run while updating Opencast. This script tinkers with the Opencast index. 

Here is the Opencast Docs entry: https://docs.opencast.org/r/18.x/admin/#upgrade/#index-rebuild
And here is the regarding Opencast PR: https://github.com/opencast/opencast/pull/6498
The scripts name is `optimize_search.sh`

Maybe @geichelberger can say something about this (if the sorting of the ACLs could be changing after the script ran).
The endpoint that gets called by SOP is `/api/events`.

Nonetheless, the Plugin should be able to compare ACLs with different sorting.