### PR TITLE
Completely remove learner acl if video is invisible

### DIFF
--- a/classes/OCRestClient/ApiEventsClient.php
+++ b/classes/OCRestClient/ApiEventsClient.php
@@ -371,13 +371,15 @@ class ApiEventsClient extends OCRestClient
                 'role'   => $course_id . '_Instructor',
                 'action' => 'write'
             ],
+        ];
 
-            [
-                'allow'  => $visibility == 'visible' || $visibility == 'free',
+        if ($visibility != 'invisible') {
+            $acl[] = [
+                'allow'  => true,
                 'role'   => $course_id . '_Learner',
                 'action' => 'read'
-            ]
-        ];
+            ];
+        }
 
         if ($visibility == 'free') {
             $acl[] = [


### PR DESCRIPTION
This fixes #1515 
- Videos set to invisible are now correctly set in Opencast circumventing inconsistencies in its search service