### PR TITLE
Fix: #1535 cannot assign workflows when choosing caputre agent

### DIFF
--- a/vueapp/components/Config/AdminConfigs.vue
+++ b/vueapp/components/Config/AdminConfigs.vue
@@ -22,7 +22,6 @@
 
             <SchedulingOptions v-if="is_scheduling_enabled"
                 :config_list="config_list"
-                @openEditModalInParent="openSchedulingEditModal"
             />
 
             <footer>

--- a/vueapp/components/Config/AdminConfigs.vue
+++ b/vueapp/components/Config/AdminConfigs.vue
@@ -25,6 +25,7 @@
             />
 
             <footer>
+                <MessageList />
                 <StudipButton icon="accept" @click.prevent="storeAdminConfig($event)">
                     <span>
                         {{ $gettext('Einstellungen speichern') }}
@@ -55,22 +56,22 @@
 <script>
 import { mapGetters } from "vuex";
 
-import StudipButton from "@studip/StudipButton";
-import StudipIcon from "@studip/StudipIcon";
-import MessageList from "@/components/MessageList";
 import GlobalOptions from "@/components/Config/GlobalOptions";
+import SchedulingEditModal from "@/components/Config/SchedulingEditModal";
 import SchedulingOptions from "@/components/Config/SchedulingOptions";
 import MessageBox from "@/components/MessageBox";
-import SchedulingEditModal from "@/components/Config/SchedulingEditModal";
+import MessageList from "@/components/MessageList";
+import StudipButton from "@studip/StudipButton";
 import StudipDialog from '@studip/StudipDialog';
+import StudipIcon from "@studip/StudipIcon";
 
 export default {
     name: "AdminConfigs",
     components: {
-        StudipButton,       StudipIcon,
-        MessageList,        MessageBox,
-        GlobalOptions,      SchedulingOptions,
-        SchedulingEditModal, StudipDialog
+        StudipButton,        StudipIcon,
+        MessageList,         MessageBox,
+        GlobalOptions,       SchedulingOptions,
+        SchedulingEditModal, StudipDialog,
     },
 
     data() {

--- a/vueapp/components/Config/SchedulingEditModal.vue
+++ b/vueapp/components/Config/SchedulingEditModal.vue
@@ -24,17 +24,16 @@
                                 {{ $gettext('Capture Agent') }}
                             </span>
 
-                            <select @change="assignCA($event)" required>
-                                <option value="" disabled :selected="!editing_resource?.capture_agent">
+                            <select v-model="selected_capture_agent" required>
+                                <option :value="null" disabled>
                                     {{ $gettext('Bitte wählen Sie einen CA.') }}
                                 </option>
                                 <template v-for="(ca_obj, index) in filtered_capture_agents" :key="index">
                                     <optgroup style="font-weight:bold;" :label="`Server #${ca_obj.id}`">
                                         <option v-for="(capture_agent, calindex) in ca_obj.list"
                                             :key="calindex"
-                                            :value="capture_agent.list_id"
-                                            :disabled="capture_agent?.in_use && `${ca_obj.id}_${editing_resource.capture_agent}` !== capture_agent.list_id"
-                                            :selected="`${ca_obj.id}_${editing_resource.capture_agent}` === capture_agent.list_id && capture_agent?.in_use"
+                                            :value="capture_agent"
+                                            :disabled="capture_agent?.in_use && capture_agent !== selected_capture_agent"
                                         >
                                             {{ capture_agent.name }}
                                         </option>
@@ -149,7 +148,6 @@ const filtered_capture_agents = computed(() => {
                         .filter((item, i, ar) => ar.indexOf(item) === i);
         for (let ci = 0; ci < configs.length; ci++) {
             let ca_cat = capture_agents.value.filter(ca => ca.config_id == configs[ci]);
-            ca_cat.map(ca => ca.list_id = `${ca.config_id}_${ca.name}`);
             if (ca_cat.length) {
                 filtered_capture_agents.push({
                     id: configs[ci],
@@ -167,6 +165,14 @@ const workflow_definitions = computed(() => {
         workflow_definitions = config_list.value?.scheduling?.workflow_definitions;
     }
     return workflow_definitions;
+});
+
+const selected_capture_agent = computed({
+    get: () => capture_agents.value.find(
+        ca => ca.name == editing_resource.value?.capture_agent
+            && ca.config_id == editing_resource.value?.config_id
+    ) ?? null,
+    set: capture_agent => assignCA(capture_agent),
 });
 
 const compiledWDList = (resource_obj) => {
@@ -238,24 +244,14 @@ const toggleCAOccupation = (capture_agent, config_id, status = true) => {
     }
 };
 
-const assignCA = (event) => {
-    event.preventDefault();
-    let value = event.target.value;
-    let selected_ca_arr = value.split('_');
-    if (selected_ca_arr.length == 2) {
-        let selected_config_id = selected_ca_arr[0];
-        let selected_ca = selected_ca_arr[1];
-        let capture_agent_obj = capture_agents.value.filter(
-            ca => ca.name == selected_ca && ca.config_id == selected_config_id
-        );
-        if (capture_agent_obj.length) {
-            let current_ca = editing_resource.value.capture_agent;
-            let current_config_id = editing_resource.value.config_id;
-            toggleCAOccupation(current_ca, current_config_id, false);
-            editing_resource.value.capture_agent = selected_ca;
-            editing_resource.value.config_id = selected_config_id;
-            toggleCAOccupation(selected_ca, selected_config_id, true);
-        }
+const assignCA = (capture_agent) => {
+    if (capture_agent && capture_agents.value.includes(capture_agent)) {
+        let current_ca = editing_resource.value.capture_agent;
+        let current_config_id = editing_resource.value.config_id;
+        toggleCAOccupation(current_ca, current_config_id, false);
+        editing_resource.value.capture_agent = capture_agent.name;
+        editing_resource.value.config_id = capture_agent.config_id;
+        toggleCAOccupation(capture_agent.name, capture_agent.config_id, true);
     }
 };
 

--- a/vueapp/components/Config/SchedulingOptions.vue
+++ b/vueapp/components/Config/SchedulingOptions.vue
@@ -32,13 +32,16 @@
                                 {{ resource.capture_agent + ` #${resource.config_id}` }}
                             </template>
                             <template v-else-if="free_capture_agents.length">
-                                <select @change="assignCA($event, resource)">
-                                    <option value="" disabled selected>
+                                <select
+                                    v-model="selected_capture_agents[resource.id]"
+                                    @change="assignCA(selected_capture_agents[resource.id], resource)"
+                                >
+                                    <option :value="null" disabled>
                                         {{ $gettext('Bitte wählen Sie einen CA.') }}
                                     </option>
                                     <template v-for="(ca_obj, index) in free_capture_agents" :key="index">
                                         <optgroup style="font-weight:bold;" :label="`Server #${ca_obj.id}`">
-                                            <option v-for="(capture_agent, calindex) in ca_obj.list" :key="calindex" :value="`${capture_agent.config_id}_` + capture_agent.name">
+                                            <option v-for="(capture_agent, calindex) in ca_obj.list" :key="calindex" :value="capture_agent">
                                                 {{ capture_agent.name }}
                                             </option>
                                         </optgroup>
@@ -135,6 +138,12 @@ export default {
 
     props: ['config_list'],
 
+    data() {
+        return {
+            selected_capture_agents: {},
+        };
+    },
+
     computed: {
         ...mapGetters(['schedulingHasUnsavedChanges']),
 
@@ -181,20 +190,12 @@ export default {
     },
 
     methods: {
-        assignCA(event, resource) {
-            event.preventDefault();
-            let value = event.target.value;
-            let selected_ca_arr = value.split('_');
-            if (selected_ca_arr.length == 2) {
-                let selected_config_id = selected_ca_arr[0];
-                let selected_ca = selected_ca_arr[1];
-                let capture_agent_obj = this.capture_agents.filter(ca => ca.name == selected_ca && ca.config_id == selected_config_id);
-                if (capture_agent_obj.length) {
-                    resource.capture_agent = selected_ca;
-                    resource.config_id = selected_config_id;
-                    this.toggleCAOccupation(selected_ca, selected_config_id, true);
-                    this.$store.dispatch('toggleSchedulingUnsavedChanges', true);
-                }
+        assignCA(capture_agent, resource) {
+            if (capture_agent && this.capture_agents.includes(capture_agent)) {
+                resource.capture_agent = capture_agent.name;
+                resource.config_id = capture_agent.config_id;
+                this.toggleCAOccupation(capture_agent.name, capture_agent.config_id, true);
+                this.$store.dispatch('toggleSchedulingUnsavedChanges', true);
             }
         },
 


### PR DESCRIPTION
fixes #1535 

- When using capture agents with an `_` in the name, the selection process breaks. This will be fixed with this PR.
- Furthermore, move the success message when storing the settings to the button for better visibility