### PR TITLE
Fix: LTI Connection check workflow and admin config page issues

### DIFF
--- a/vueapp/app.js
+++ b/vueapp/app.js
@@ -49,7 +49,7 @@ window.addEventListener("DOMContentLoaded", function() {
                 return Promise.reject(error);
             }
 
-            if (error?.response?.data !== undefined) {
+            if (error?.response?.data !== undefined && !error.config?.suppressErrorMessage) {
                 store.dispatch('addMessage', error.response);
             }
 

--- a/vueapp/components/Config/EditServer.vue
+++ b/vueapp/components/Config/EditServer.vue
@@ -304,6 +304,8 @@ export default {
                     return;
                 }
                 else if (data.message.type === 'success') {
+                    this.$emit('stored', data.config);
+
                     if (this.currentId !== 'new') {
                         // Just show success message if server was edited
                         this.$store.dispatch('addMessage', {

--- a/vueapp/components/Config/I18NText.vue
+++ b/vueapp/components/Config/I18NText.vue
@@ -12,7 +12,7 @@
                     <input
                         v-if="type === 'text'"
                         type="text"
-                        ref="`studip_i18n_text_` + lang.id"
+                        :ref="`studip_i18n_text_${lang.id}`"
                         :name="`studip_i18n_text_` + uuid + '_' + lang.id"
                         v-model="currentInputValue"
                         @keyup="updateInputValue"
@@ -21,7 +21,7 @@
                         v-else-if="type === 'textarea'"
                         :value="currentText[lang.id]"
                         :id="`studip_wysiwyg_` + uuid + '_' + lang.id"
-                        :ref="`studip_wysiwyg_` + lang.id"
+                        :ref="`studip_wysiwyg_${lang.id}`"
                         class="studip-wysiwyg"
                     >
                     </textarea>
@@ -121,8 +121,8 @@ export default {
             return OpencastPlugin.ASSETS_URL + 'images/languages/' + lang.picture;
         },
 
-        initCKE() {
-            if (!STUDIP.wysiwyg_enabled) {
+        async initCKE() {
+            if (typeof STUDIP?.wysiwyg?.replace !== 'function') {
                 return false;
             }
 
@@ -130,39 +130,27 @@ export default {
                 return false;
             }
 
-            let textarea = this.$refs['studip_wysiwyg_' + this.selectedLang.id][0];
+            const langId = this.selectedLang.id;
+            const textarea = this.$refs['studip_wysiwyg_' + langId]?.[0];
 
-            if (!this.wysiwyg_editor[this.selectedLang.id]) {
-                this.checkEditor();
+            if (!textarea || this.wysiwyg_editor[langId]) {
+                return Boolean(textarea);
             }
+
+            const editor = await STUDIP.wysiwyg.replace(textarea);
+            this.wysiwyg_editor[langId] = editor;
+
+            // using toRaw to remove Vue proxys. They do not work well with CKEditor
+            toRaw(editor).ui.focusTracker.on('change:isFocused', () => {
+                this.updateValue(toRaw(editor).getData(), langId);
+            });
 
             return true;
         },
 
-        checkEditor()
+        updateValue(value, langId = this.selectedLang.id)
         {
-            let view = this;
-            let textarea = this.$refs['studip_wysiwyg_' + this.selectedLang.id][0];
-
-            if (!STUDIP.wysiwyg.getEditor(textarea)) {
-                STUDIP.wysiwyg.replace(textarea);
-                setTimeout(() => {
-                    view.checkEditor()
-                }, 500);
-                return;
-            }
-
-            this.wysiwyg_editor[this.selectedLang.id] = STUDIP.wysiwyg.getEditor(textarea);
-
-            // using toRaw to remove Vue proxys. They do not work well with CKEditor
-            toRaw(this.wysiwyg_editor[this.selectedLang.id]).ui.focusTracker.on( 'change:isFocused', () => {
-                view.updateValue(toRaw(view.wysiwyg_editor[view.selectedLang.id]).getData());
-            });
-        },
-
-        updateValue(value)
-        {
-            this.currentText[this.selectedLang.id] = value;
+            this.currentText[langId] = value;
 
             // clean anything else besides languages
             for (let id in this.currentText) {

--- a/vueapp/components/Config/I18NText.vue
+++ b/vueapp/components/Config/I18NText.vue
@@ -53,7 +53,7 @@ export default {
 
     props: {
         text: {
-            type: String
+            type: [String, Object]
         },
         languages: {
             type: Object
@@ -92,15 +92,19 @@ export default {
         if (Object.keys(this.languages).includes('default')) {
             this.selectedLang = this.languages.default;
         }
-        let json;
-        try {
-            json = JSON.parse(this.text);
-        } catch (e) {
-            json = {}
+        let json = {};
+        if (typeof this.text === 'string') {
+            try {
+                json = JSON.parse(this.text);
+            } catch (e) {
+                json = {};
+            }
+        } else if (this.text) {
+            json = { ...this.text };
         }
 
         this.currentText = json;
-        this.currentInputValue = this.text[this.selectedLang.id];
+        this.currentInputValue = this.currentText[this.selectedLang.id] ?? null;
     },
 
     beforeUnmount() {
@@ -175,7 +179,7 @@ export default {
                 this.initCKE();
                 return;
             }
-            this.currentInputValue = this.text?.[this.selectedLang.id] ?? null;
+            this.currentInputValue = this.currentText[this.selectedLang.id] ?? null;
         },
 
         updateInputValue() {

--- a/vueapp/components/Config/ServerCard.vue
+++ b/vueapp/components/Config/ServerCard.vue
@@ -22,7 +22,7 @@
             <span class="oc--admin--server-icons">
                 <div data-tooltip class="tooltip" v-if="!isAddCard && checkFailed">
                     <span class="tooltip-content" style="display: none">
-                        {{ $gettext('Verbindungstest fehlgeschlagen.') }}
+                        {{ $gettext('LTI Verbindungstest fehlgeschlagen.') }}
                     </span>
                     <studip-icon shape="exclaim-circle" role="status-red" :size="32"/>
                 </div>
@@ -49,7 +49,8 @@
         <EditServer v-if="isShow"
             :id="config ? config.id : 'new'"
             :config="config"
-            @close="isShow = false;"
+            @stored="handleStored"
+            @close="handleClose"
         />
     </div>
 </template>
@@ -80,15 +81,18 @@ export default {
             isShow: false,
             interval: null,
             interval_counter: 0,
-            error_msg: {
-                type: 'error',
-                text: this.$gettext('Überprüfung der Verbindung fehlgeschlagen! '
-                    + 'Kontrollieren Sie die eingetragenen Daten und stellen Sie sicher, '
+            interval_limit: 10,
+            checkAfterClose: false,
+            storedConfigId: null,
+            connection_info_msg: {
+                type: 'info',
+                text: this.$gettext('Überprüfung der LTI Verbindung fehlgeschlagen! '
+                    + 'Kontrollieren Sie die eingetragenen Daten (LTI Consumerkey und LTI Consumersecret) und stellen Sie sicher, '
                     + 'dass Cross-Origin Aufrufe von dieser Domain aus möglich sind! '
                     + 'Denken Sie auch daran, in Opencast die korrekten access-control-allow-* '
                     + 'Header zu setzen.'
                 ),
-                dialog: true
+                dialog: false
             }
         }
     },
@@ -101,7 +105,8 @@ export default {
 
     computed: {
         ...mapGetters([
-            'isLTIAuthenticated'
+            'isLTIAuthenticated',
+            'simple_config_list'
         ]),
 
         checkFailed() {
@@ -146,21 +151,81 @@ export default {
 
         showEditServer() {
             this.isShow = true;
+        },
 
-            if (this.checkFailed) {
-                this.$store.dispatch('addMessage', this.error_msg);
+        handleStored(config) {
+            const configId = config?.id ?? this.config?.id;
+            if (!configId) {
+                return;
             }
+
+            this.stopConnectionCheck();
+            this.storedConfigId = configId;
+            this.checkAfterClose = true;
+            this.$store.dispatch('resetLTIAuthentication', configId);
+            this.$store.dispatch('removeMessage', this.connection_info_msg);
+        },
+
+        handleClose() {
+            this.isShow = false;
+
+            if (!this.checkAfterClose) {
+                return;
+            }
+
+            this.checkAfterClose = false;
+            this.$nextTick(() => this.startConnectionCheck(this.storedConfigId));
+        },
+
+        async startConnectionCheck(configId) {
+            await this.$store.dispatch('authenticateLti');
+
+            const server = this.simple_config_list?.server?.[configId];
+            if (!server) {
+                return;
+            }
+
+            const check = async () => {
+                await this.$store.dispatch('checkLTIAuthentication', server);
+                this.interval_counter++;
+
+                if (this.isLTIAuthenticated[configId] || this.interval_counter >= this.interval_limit) {
+                    this.stopConnectionCheck();
+                }
+            };
+
+            // The new LTI iframe must finish its signed launch before checking the
+            // session. An immediate request can still see the previous session and
+            // incorrectly stop the check before the updated credentials are used.
+            this.interval = setTimeout(async () => {
+                await check();
+                if (!this.isLTIAuthenticated[configId] && this.interval_counter < this.interval_limit) {
+                    this.interval = setInterval(check, 2000);
+                }
+            }, 2000);
+        },
+
+        stopConnectionCheck() {
+            if (this.interval) {
+                clearInterval(this.interval);
+                this.interval = null;
+            }
+            this.interval_counter = 0;
         },
     },
 
     watch: {
         checkFailed: function (newVal) {
-            if (newVal && this.isShow) {
-                this.$store.dispatch('addMessage', this.error_msg);
+            if (newVal && !this.isShow) {
+                this.$store.dispatch('addMessage', this.connection_info_msg);
             } else {
-                this.$store.dispatch('removeMessage', this.error_msg);
+                this.$store.dispatch('removeMessage', this.connection_info_msg);
             }
         }
+    },
+
+    beforeUnmount() {
+        this.stopConnectionCheck();
     }
 }
 </script>

--- a/vueapp/components/Config/UploadWorkflowConfigurationOptions.vue
+++ b/vueapp/components/Config/UploadWorkflowConfigurationOptions.vue
@@ -4,7 +4,7 @@
             <legend>
                 {{ $gettext('Upload-Workflow-Konfigurationsoptionen') }}
             </legend>
-            <fieldset v-for="(item, key) in configurationPanelOptions" :key="item.name + uploadWorkflowIndex">
+            <fieldset v-for="(item, key) in configurationPanelOptions" :key="`${key}-${uploadWorkflowIndex}`">
                 <label>
                     <span>
                         {{ $gettext('Option ID') }}

--- a/vueapp/components/LtiAuth.vue
+++ b/vueapp/components/LtiAuth.vue
@@ -7,7 +7,7 @@
             <!-- iterate over all opencast nodes for this server as well -->
             <iframe
                 v-for="i in server.lti_num"
-                v-bind:key="i"
+                v-bind:key="`${ltiAuthRevision}-${server.id}-${i}`"
                 :src="authUrl(server.id, i - 1)">
             </iframe>
         </template>
@@ -30,16 +30,18 @@ export default {
     },
 
     computed: {
-        ...mapGetters(['simple_config_list', 'isLTIAuthenticated', 'cid']),
+        ...mapGetters(['simple_config_list', 'isLTIAuthenticated', 'ltiAuthRevision', 'cid']),
     },
 
     methods: {
         authUrl(config_id, num) {
+            const authRevision = '&auth_revision=' + this.ltiAuthRevision;
+
             // check, if we are in a course
             if (this.cid) {
-                return window.OpencastPlugin.AUTH_URL + '/' + num + '?config_id=' + config_id + '&cid=' + this.cid;
+                return window.OpencastPlugin.AUTH_URL + '/' + num + '?config_id=' + config_id + '&cid=' + this.cid + authRevision;
             } else {
-                return window.OpencastPlugin.AUTH_URL + '/' + num + '?config_id=' + config_id;
+                return window.OpencastPlugin.AUTH_URL + '/' + num + '?config_id=' + config_id + authRevision;
             }
         },
 
@@ -71,7 +73,10 @@ export default {
 
     mounted() {
         this.$store.dispatch('simpleConfigListRead').then(() => {
-            this.checkLTIPeriodically();
+            // ServerCard starts the check after a stored admin dialog has closed.
+            if (this.$route.name !== 'admin') {
+                this.checkLTIPeriodically();
+            }
         });
     }
 }

--- a/vueapp/store/opencast.module.js
+++ b/vueapp/store/opencast.module.js
@@ -13,6 +13,7 @@ const state = {
     userCourses: [],
     userList: [],
     isLTIAuthenticated: {},
+    ltiAuthRevision: 0,
     currentLTIUser: {},
     opencastOffline: false
 }
@@ -51,6 +52,9 @@ const getters = {
     isLTIAuthenticated(state) {
         return state.isLTIAuthenticated;
     },
+    ltiAuthRevision(state) {
+        return state.ltiAuthRevision;
+    },
     currentLTIUser(state) {
         return state.currentLTIUser;
     },
@@ -61,6 +65,17 @@ const getters = {
 
 
 const actions = {
+    resetLTIAuthentication({ commit }, server) {
+        commit('setCurrentLTIUser', {
+            server,
+            user: null
+        });
+        commit('setLTIStatus', {
+            server,
+            authenticated: null
+        });
+    },
+
     updateCid({commit}, cid) {
         commit('setCid', cid);
     },
@@ -129,9 +144,11 @@ const actions = {
         commit('clearPaging');
     },
 
-    async authenticateLti({ dispatch }) {
-        // by reloading the simple config, LtiAuth.vue reloads the iframe for lti authentication
-        return dispatch('simpleConfigListRead');
+    async authenticateLti({ commit, dispatch }) {
+        const config = await dispatch('simpleConfigListRead');
+        // Force LtiAuth to create new iframes, even when their URLs did not change.
+        commit('incrementLTIAuthRevision');
+        return config;
     },
 
     setUpload({ commit }, data) {
@@ -149,6 +166,7 @@ const actions = {
                 url: server.name + "/lti/info.json",
                 crossDomain: true,
                 withCredentials: true,
+                suppressErrorMessage: true,
                 headers: {
                     "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
                 }
@@ -194,6 +212,7 @@ const actions = {
                 url: server.name + "/info/me.json",
                 crossDomain: true,
                 withCredentials: true,
+                suppressErrorMessage: true,
                 headers: {
                     "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
                 }
@@ -266,6 +285,10 @@ const mutations = {
 
     setLTIStatus(state, params) {
         state.isLTIAuthenticated[params.server] = params.authenticated;
+    },
+
+    incrementLTIAuthRevision(state) {
+        state.ltiAuthRevision++;
     },
 
     setCurrentLTIUser(state, params) {


### PR DESCRIPTION
fixes #1534

**LTI connection checks**
- Run server connection checks only after saving and closing the configuration dialog.
- Reset previous check results on every save.
- Re-authenticate LTI using updated credentials before checking.
- Display connection failures as informational messages in the admin view.
- Suppress expected 403 messages from LTI probes.

**Other issues**
- WYSIWYG Editor is again used for text fields
- Fixed some warnings